### PR TITLE
feat(Karma): add actualBalanceOf

### DIFF
--- a/status-network-contracts/src/Karma.sol
+++ b/status-network-contracts/src/Karma.sol
@@ -446,6 +446,16 @@ contract Karma is Initializable, ERC20VotesUpgradeable, UUPSUpgradeable, AccessC
     }
 
     /**
+     * @notice Returns the actual token balance of an account.
+     * @dev This value excludes virtual Karma distributed by reward distributors.
+     * @param account The account to get the token balance of.
+     * @return The actual token balance of the account.
+     */
+    function actualTokenBalanceOf(address account) public view returns (uint256) {
+        return super.balanceOf(account);
+    }
+
+    /**
      * @notice Returns the balance of a reward distributor.
      * @dev The balance of a reward distributor is the balance of the actual tokens held by the distributor.
      * @param distributor The address of the reward distributor.

--- a/status-network-contracts/test/Karma.t.sol
+++ b/status-network-contracts/test/Karma.t.sol
@@ -136,6 +136,28 @@ contract KarmaTest is Test {
         assertEq(balance, expectedBalance);
     }
 
+    function testActualTokenBalanceOf() public {
+        vm.startBroadcast(owner);
+        karma.setReward(address(distributor1), 1000 ether, 1000);
+        karma.setReward(address(distributor2), 2000 ether, 2000);
+        vm.stopBroadcast();
+
+        distributor1.setTotalKarmaShares(1000 ether);
+        distributor2.setTotalKarmaShares(2000 ether);
+
+        distributor1.setUserKarmaShare(alice, 1000e18);
+        distributor2.setUserKarmaShare(alice, 2000e18);
+
+        vm.prank(owner);
+        karma.mint(alice, 500e18);
+
+        uint256 balance = karma.balanceOf(alice);
+        uint256 actualBalance = karma.actualTokenBalanceOf(alice);
+
+        assertEq(balance, 3500e18);
+        assertEq(actualBalance, 500e18);
+    }
+
     function testMintOnlyAdmin() public {
         vm.startBroadcast(owner);
         karma.setReward(address(distributor1), 1000 ether, 1000);


### PR DESCRIPTION
This PR adds a new function to Karma, `actualBalanceOf`, that returns the balance of a user without counting the virtual balance from distributors. 