### PR TITLE
feat(RLN): queue slash commitments to avoid front-running at reveal-time

### DIFF
--- a/status-network-contracts/src/rln/RLN.sol
+++ b/status-network-contracts/src/rln/RLN.sol
@@ -16,6 +16,8 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     error RLN__SetIsFull();
     error RLN__Unauthorized();
     error RLN__InvalidCommitment();
+    error RLN__RevealWindowNotStarted();
+    error RLN__InvalidSlashRevealWindowTime(uint256 windowTime);
 
     /// @dev Emmited when a new member registered.
     /// @param identityCommitment: `identityCommitment`;
@@ -26,6 +28,11 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     /// @param index: index of `identityCommitment`;
     /// @param slasher: address of slasher (msg.sender).
     event MemberSlashed(uint256 index, address slasher);
+
+    /// @dev Emitted when the slash reveal window time is updated.
+    /// @param newWindowTime: the new reveal window time in seconds.
+    /// @param updatedBy: address of the account that performed the update.
+    event SlashRevealWindowTimeUpdated(uint256 newWindowTime, address indexed updatedBy);
 
     /// @dev User metadata struct.
     /// @param userAddress: address of depositor;
@@ -53,8 +60,15 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     /// @dev Poseidon hasher contract.
     IPoseidonHasher public poseidonHasher;
 
+    /// @dev Time window for reveal after commit (default 1 hour).
+    uint256 public slashRevealWindowTime;
+
+    /// @dev Last reveal start time for each account to be slashed.
+    mapping(address account => uint256 lastRevealStartTime) public lastRevealStartTime;
+
     /// @dev Slash commitments mapping for the commit-reveal scheme.
-    mapping(bytes32 hash => bool commited) public slashCommitments;
+    /// Maps account => commitmentHash => revealStartTime.
+    mapping(address account => mapping(bytes32 hash => uint256 revealStartTime)) public slashCommitments;
 
     constructor() {
         _disableInitializers();
@@ -87,6 +101,9 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
 
         karma = Karma(_token);
         poseidonHasher = IPoseidonHasher(_poseidonHasher);
+
+        // Set default reveal window time to 1 hour
+        slashRevealWindowTime = 1 hours;
     }
 
     /**
@@ -97,6 +114,20 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         if (!hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert RLN__Unauthorized();
         }
+    }
+
+    /// @dev Sets the slash reveal window time.
+    /// @param _slashRevealWindowTime: new reveal window time in seconds.
+    /// @notice The window time must be at least 1 second and no more than 365 days.
+    ///         A non-zero value is required to ensure the queuing mechanism functions correctly.
+    ///         An excessively large value could lock commitments indefinitely.
+    function setSlashRevealWindowTime(uint256 _slashRevealWindowTime) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_slashRevealWindowTime == 0 || _slashRevealWindowTime > 1 days) {
+            revert RLN__InvalidSlashRevealWindowTime(_slashRevealWindowTime);
+        }
+
+        slashRevealWindowTime = _slashRevealWindowTime;
+        emit SlashRevealWindowTimeUpdated(_slashRevealWindowTime, msg.sender);
     }
 
     /// @dev Adds `identityCommitment` to the registry set and takes the necessary stake amount.
@@ -143,28 +174,47 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     /// The slasher must first commit to a hash of (privateKey, rewardRecipient) before revealing
     /// the actual values. This prevents front-running attacks where others could observe the
     /// privateKey in the mempool and slash the member themselves with a different reward recipient.
+    /// The commit is queued by account, with each new commit having a reveal window after the previous one.
     ///
+    /// @param account: the account to be slashed (address associated with the identity commitment).
     /// @param hash: keccak256 hash of abi.encodePacked(privateKey, rewardRecipient).
-    function slashCommit(bytes32 hash) external onlyRole(SLASHER_ROLE) {
-        slashCommitments[hash] = true;
+    function slashCommit(address account, bytes32 hash) external onlyRole(SLASHER_ROLE) {
+        uint256 lastRevealTime = lastRevealStartTime[account];
+        // If this is the first commit for this account, start from current time
+        // Otherwise, queue after the last reveal time
+        uint256 baseTime = lastRevealTime > block.timestamp ? lastRevealTime : block.timestamp;
+        uint256 revealStartTime = baseTime + slashRevealWindowTime;
+
+        slashCommitments[account][hash] = revealStartTime;
+        lastRevealStartTime[account] = revealStartTime;
     }
 
     /// @dev Reveals and executes a previously committed slash operation.
     /// @notice This is the second step of the commit-reveal scheme for slashing.
     /// After committing the hash, the slasher reveals the actual privateKey and rewardRecipient.
-    /// The function verifies that these values match a previously committed hash, then executes
-    /// the slash. This two-step process prevents front-running while ensuring the slasher cannot
-    /// change the parameters after commitment.
+    /// The function verifies that these values match a previously committed hash and that the
+    /// reveal window has started. This two-step process with queuing prevents front-running
+    /// while ensuring the slasher cannot change the parameters after commitment.
     ///
+    /// @param account: the account to be slashed (address associated with the identity commitment).
     /// @param privateKey: RLN private key as bytes32.
     /// @param rewardRecipient: Address that will receive the slash reward from the Karma contract.
-    function slashReveal(bytes32 privateKey, address rewardRecipient) external onlyRole(SLASHER_ROLE) {
+    function slashReveal(address account, bytes32 privateKey, address rewardRecipient)
+        external
+        onlyRole(SLASHER_ROLE)
+    {
         bytes32 hash = keccak256(abi.encodePacked(privateKey, rewardRecipient));
-        if (!slashCommitments[hash]) {
+        uint256 revealStartTime = slashCommitments[account][hash];
+
+        if (revealStartTime == 0) {
             revert RLN__InvalidCommitment();
         }
 
-        delete slashCommitments[hash];
+        if (block.timestamp < revealStartTime) {
+            revert RLN__RevealWindowNotStarted();
+        }
+
+        delete slashCommitments[account][hash];
         slash(privateKey, rewardRecipient);
     }
 }

--- a/status-network-contracts/src/rln/RLN.sol
+++ b/status-network-contracts/src/rln/RLN.sol
@@ -179,11 +179,14 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     /// @param account: the account to be slashed (address associated with the identity commitment).
     /// @param hash: keccak256 hash of abi.encodePacked(privateKey, rewardRecipient).
     function slashCommit(address account, bytes32 hash) external onlyRole(SLASHER_ROLE) {
-        uint256 lastRevealTime = lastRevealStartTime[account];
-        // If this is the first commit for this account, start from current time
-        // Otherwise, queue after the last reveal time
-        uint256 baseTime = lastRevealTime > block.timestamp ? lastRevealTime : block.timestamp;
-        uint256 revealStartTime = baseTime + slashRevealWindowTime;
+        uint256 lastReveal = lastRevealStartTime[account];
+        uint256 revealStartTime;
+
+        if (lastReveal == 0 || lastReveal + slashRevealWindowTime < block.timestamp) {
+            revealStartTime = block.timestamp;
+        } else {
+            revealStartTime = lastReveal + slashRevealWindowTime;
+        }
 
         slashCommitments[account][hash] = revealStartTime;
         lastRevealStartTime[account] = revealStartTime;
@@ -199,7 +202,11 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     /// @param account: the account to be slashed (address associated with the identity commitment).
     /// @param privateKey: RLN private key as bytes32.
     /// @param rewardRecipient: Address that will receive the slash reward from the Karma contract.
-    function slashReveal(address account, bytes32 privateKey, address rewardRecipient)
+    function slashReveal(
+        address account,
+        bytes32 privateKey,
+        address rewardRecipient
+    )
         external
         onlyRole(SLASHER_ROLE)
     {

--- a/status-network-contracts/test/RLN.t.sol
+++ b/status-network-contracts/test/RLN.t.sol
@@ -327,12 +327,17 @@ contract RLNTest is Test {
         vm.prank(registerAddr);
         rln.register(identityCommitment0, user1Addr);
 
-        // Commit the slash
-        bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        // Commit 1 (wrong key)
+        bytes32 hash1 = keccak256(abi.encodePacked(privateKey1, rewardRecipientAddr));
         vm.prank(slasherAddr);
-        rln.slashCommit(user1Addr, hash);
+        rln.slashCommit(user1Addr, hash1);
 
-        // Attempt to reveal before the window starts
+        // Commit 2 (right key)
+        bytes32 hash2 = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        vm.prank(slasherAddr);
+        rln.slashCommit(user1Addr, hash2);
+
+        // Attempt to reveal before the window starts for the second slash commitment
         vm.expectRevert(RLN.RLN__RevealWindowNotStarted.selector);
         vm.prank(slasherAddr);
         rln.slashReveal(user1Addr, privateKey0, rewardRecipientAddr);

--- a/status-network-contracts/test/RLN.t.sol
+++ b/status-network-contracts/test/RLN.t.sol
@@ -232,21 +232,24 @@ contract RLNTest is Test {
             )
         );
         vm.prank(user1Addr);
-        rln.slashCommit(hash);
+        rln.slashCommit(user1Addr, hash);
     }
 
     function test_SlashCommitAddsNewHashWithSlashRole() public {
         bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
 
         // Verify commitment doesn't exist yet
-        assertFalse(rln.slashCommitments(hash));
+        assertEq(rln.slashCommitments(user1Addr, hash), 0);
 
         // Commit with slash role
         vm.prank(slasherAddr);
-        rln.slashCommit(hash);
+        rln.slashCommit(user1Addr, hash);
 
-        // Verify commitment was added
-        assertTrue(rln.slashCommitments(hash));
+        // Verify commitment was added with a revealStartTime
+        assertGt(rln.slashCommitments(user1Addr, hash), 0);
+
+        // Verify lastRevealStartTime was updated
+        assertGt(rln.lastRevealStartTime(user1Addr), 0);
     }
 
     function test_SlashRevealRevertsIfNoSlashRole() public {
@@ -260,14 +263,14 @@ contract RLNTest is Test {
             )
         );
         vm.prank(user1Addr);
-        rln.slashReveal(privateKey0, rewardRecipientAddr);
+        rln.slashReveal(user1Addr, privateKey0, rewardRecipientAddr);
     }
 
     function test_SlashRevealRevertsIfCommitmentDoesntExist() public {
         // Attempt to reveal without committing first
         vm.expectRevert(RLN.RLN__InvalidCommitment.selector);
         vm.prank(slasherAddr);
-        rln.slashReveal("1234", rewardRecipientAddr);
+        rln.slashReveal(user1Addr, "1234", rewardRecipientAddr);
     }
 
     function test_SlashRevealSlashesAccountAndRemovesHash() public {
@@ -283,10 +286,14 @@ contract RLNTest is Test {
         // Commit the slash
         bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
         vm.prank(slasherAddr);
-        rln.slashCommit(hash);
+        rln.slashCommit(user1Addr, hash);
 
-        // Verify commitment exists
-        assertTrue(rln.slashCommitments(hash));
+        // Verify commitment exists with a revealStartTime
+        uint256 revealStartTime = rln.slashCommitments(user1Addr, hash);
+        assertGt(revealStartTime, 0);
+
+        // Warp time to allow reveal (skip to the reveal window)
+        vm.warp(revealStartTime);
 
         // Burn event
         vm.expectEmit(true, true, true, true);
@@ -302,15 +309,86 @@ contract RLNTest is Test {
 
         // Reveal and slash
         vm.prank(slasherAddr);
-        rln.slashReveal(privateKey0, rewardRecipientAddr);
+        rln.slashReveal(user1Addr, privateKey0, rewardRecipientAddr);
 
         // Verify commitment was removed
-        assertFalse(rln.slashCommitments(hash));
+        assertEq(rln.slashCommitments(user1Addr, hash), 0);
 
         // Verify member was slashed
         (address userAddress, uint256 userIndex) = _memberData(identityCommitment0);
         assertEq(userAddress, address(0));
         assertEq(userIndex, 0);
+    }
+
+    function test_SlashRevealRevertsIfRevealWindowNotStarted() public {
+        vm.prank(owner);
+        karma.mint(user1Addr, 10 ether);
+
+        vm.prank(registerAddr);
+        rln.register(identityCommitment0, user1Addr);
+
+        // Commit the slash
+        bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        vm.prank(slasherAddr);
+        rln.slashCommit(user1Addr, hash);
+
+        // Attempt to reveal before the window starts
+        vm.expectRevert(RLN.RLN__RevealWindowNotStarted.selector);
+        vm.prank(slasherAddr);
+        rln.slashReveal(user1Addr, privateKey0, rewardRecipientAddr);
+    }
+
+    function test_SlashCommitCreatesQueueForMultipleCommits() public {
+        // Commit three slashes for the same account
+        bytes32 hash1 = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        bytes32 hash2 = keccak256(abi.encodePacked(privateKey1, rewardRecipientAddr));
+        bytes32 hash3 = keccak256(abi.encodePacked(privateKey2, rewardRecipientAddr));
+
+        vm.startPrank(slasherAddr);
+        rln.slashCommit(user1Addr, hash1);
+        uint256 revealTime1 = rln.slashCommitments(user1Addr, hash1);
+
+        rln.slashCommit(user1Addr, hash2);
+        uint256 revealTime2 = rln.slashCommitments(user1Addr, hash2);
+
+        rln.slashCommit(user1Addr, hash3);
+        uint256 revealTime3 = rln.slashCommitments(user1Addr, hash3);
+        vm.stopPrank();
+
+        // Verify that each subsequent commit has a later reveal time
+        assertGt(revealTime1, 0);
+        assertEq(revealTime2, revealTime1 + rln.slashRevealWindowTime());
+        assertEq(revealTime3, revealTime2 + rln.slashRevealWindowTime());
+
+        // Verify lastRevealStartTime was updated to the last commit's time
+        assertEq(rln.lastRevealStartTime(user1Addr), revealTime3);
+    }
+
+    function test_SetSlashRevealWindowTime() public {
+        uint256 newWindowTime = 2 hours;
+
+        // Set new window time as admin
+        vm.prank(adminAddr);
+        rln.setSlashRevealWindowTime(newWindowTime);
+
+        // Verify it was updated
+        assertEq(rln.slashRevealWindowTime(), newWindowTime);
+    }
+
+    function test_SetSlashRevealWindowTimeRevertsIfNotAdmin() public {
+        uint256 newWindowTime = 2 hours;
+
+        // Attempt to set new window time without admin role
+        vm.expectRevert(
+            abi.encodePacked(
+                "AccessControl: account ",
+                Strings.toHexString(uint160(user1Addr)),
+                " is missing role ",
+                Strings.toHexString(uint256(rln.DEFAULT_ADMIN_ROLE()), 32)
+            )
+        );
+        vm.prank(user1Addr);
+        rln.setSlashRevealWindowTime(newWindowTime);
     }
 
     /* ========== HELPERS ========== */


### PR DESCRIPTION
This PR updates the slash commit/reveal scheme to avoid front-running at reveal-time. 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.