### PR TITLE
Rln fixes

### DIFF
--- a/status-network-contracts/src/rln/RLN.sol
+++ b/status-network-contracts/src/rln/RLN.sol
@@ -117,6 +117,23 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         }
     }
 
+    /// @dev Slashes identity with privateKey.
+    /// @param privateKey: RLN private key as bytes32;
+    /// @param rewardRecipient: Address that will receive the slash reward;
+    function _slash(bytes32 privateKey, address rewardRecipient) internal onlyRole(SLASHER_ROLE) {
+        // Hash the private key using Poseidon to get identityCommitment
+        uint256 identityCommitment = poseidonHasher.hash(uint256(privateKey));
+
+        User memory member = members[identityCommitment];
+        if (member.userAddress == address(0)) {
+            revert RLN__MemberNotFound();
+        }
+        karma.slash(member.userAddress, rewardRecipient);
+        delete members[identityCommitment];
+
+        emit MemberSlashed(member.index, msg.sender);
+    }
+
     /// @dev Sets the slash reveal window time.
     /// @param _slashRevealWindowTime: new reveal window time in seconds.
     /// @notice The window time must be at least 1 second and no more than 365 days.
@@ -152,23 +169,6 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         unchecked {
             identityCommitmentIndex = index + 1;
         }
-    }
-
-    /// @dev Slashes identity with privateKey.
-    /// @param privateKey: RLN private key as bytes32;
-    /// @param rewardRecipient: Address that will receive the slash reward;
-    function slash(bytes32 privateKey, address rewardRecipient) public onlyRole(SLASHER_ROLE) {
-        // Hash the private key using Poseidon to get identityCommitment
-        uint256 identityCommitment = poseidonHasher.hash(uint256(privateKey));
-
-        User memory member = members[identityCommitment];
-        if (member.userAddress == address(0)) {
-            revert RLN__MemberNotFound();
-        }
-        karma.slash(member.userAddress, rewardRecipient);
-        delete members[identityCommitment];
-
-        emit MemberSlashed(member.index, msg.sender);
     }
 
     /// @dev Commits to a future slash operation using a hash.
@@ -225,6 +225,6 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         }
 
         delete slashCommitments[account][hash];
-        slash(privateKey, rewardRecipient);
+        _slash(privateKey, rewardRecipient);
     }
 }

--- a/status-network-contracts/src/rln/RLN.sol
+++ b/status-network-contracts/src/rln/RLN.sol
@@ -117,23 +117,6 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         }
     }
 
-    /// @dev Slashes identity with privateKey.
-    /// @param privateKey: RLN private key as bytes32;
-    /// @param rewardRecipient: Address that will receive the slash reward;
-    function _slash(bytes32 privateKey, address rewardRecipient) internal onlyRole(SLASHER_ROLE) {
-        // Hash the private key using Poseidon to get identityCommitment
-        uint256 identityCommitment = poseidonHasher.hash(uint256(privateKey));
-
-        User memory member = members[identityCommitment];
-        if (member.userAddress == address(0)) {
-            revert RLN__MemberNotFound();
-        }
-        karma.slash(member.userAddress, rewardRecipient);
-        delete members[identityCommitment];
-
-        emit MemberSlashed(member.index, msg.sender);
-    }
-
     /// @dev Computes the slash commitment key with the slasher address and hash.
     /// The slasher address is included to ensure uniqueness per slasher, not allowing anyone else to override the same
     /// hash without even knowing the private key.
@@ -237,6 +220,23 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         }
 
         delete slashCommitments[account][key];
-        _slash(privateKey, rewardRecipient);
+
+        uint256 identityCommitment = poseidonHasher.hash(uint256(privateKey));
+        User memory member = members[identityCommitment];
+        if (member.userAddress == address(0)) {
+            revert RLN__MemberNotFound();
+        }
+
+        // We make sure that the account slashed matches the account used during the commit phase
+        // otherwise someone could front-run the slasher by committing to slash a different account
+        // to skip the queuing mechanism.
+        if (account != member.userAddress) {
+            revert RLN__InvalidCommitment();
+        }
+
+        karma.slash(member.userAddress, rewardRecipient);
+        delete members[identityCommitment];
+
+        emit MemberSlashed(member.index, msg.sender);
     }
 }

--- a/status-network-contracts/src/rln/RLN.sol
+++ b/status-network-contracts/src/rln/RLN.sol
@@ -134,6 +134,16 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
         emit MemberSlashed(member.index, msg.sender);
     }
 
+    /// @dev Computes the slash commitment key with the slasher address and hash.
+    /// The slasher address is included to ensure uniqueness per slasher, not allowing anyone else to override the same
+    /// hash without even knowing the private key.
+    /// @param sender: address of the slasher;
+    /// @param hash: keccak256 hash of abi.encodePacked(privateKey, rewardRecipient);
+    /// @return bytes32: the computed commitment key.
+    function _slashCommitmentKey(address sender, bytes32 hash) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(sender, hash));
+    }
+
     /// @dev Sets the slash reveal window time.
     /// @param _slashRevealWindowTime: new reveal window time in seconds.
     /// @notice The window time must be at least 1 second and no more than 365 days.
@@ -190,7 +200,8 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
             revealStartTime = lastReveal + slashRevealWindowTime;
         }
 
-        slashCommitments[account][hash] = revealStartTime;
+        bytes32 key = _slashCommitmentKey(msg.sender, hash);
+        slashCommitments[account][key] = revealStartTime;
         lastRevealStartTime[account] = revealStartTime;
     }
 
@@ -214,7 +225,8 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
     {
         /// forge-lint: disable-next-line(asm-keccak256)
         bytes32 hash = keccak256(abi.encodePacked(privateKey, rewardRecipient));
-        uint256 revealStartTime = slashCommitments[account][hash];
+        bytes32 key = _slashCommitmentKey(msg.sender, hash);
+        uint256 revealStartTime = slashCommitments[account][key];
 
         if (revealStartTime == 0) {
             revert RLN__InvalidCommitment();
@@ -224,7 +236,7 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
             revert RLN__RevealWindowNotStarted();
         }
 
-        delete slashCommitments[account][hash];
+        delete slashCommitments[account][key];
         _slash(privateKey, rewardRecipient);
     }
 }

--- a/status-network-contracts/src/rln/RLN.sol
+++ b/status-network-contracts/src/rln/RLN.sol
@@ -146,7 +146,7 @@ contract RLN is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
 
     /// @dev Sets the slash reveal window time.
     /// @param _slashRevealWindowTime: new reveal window time in seconds.
-    /// @notice The window time must be at least 1 second and no more than 365 days.
+    /// @notice The window time must be at least 1 second and no more than 1 day.
     ///         A non-zero value is required to ensure the queuing mechanism functions correctly.
     ///         An excessively large value could lock commitments indefinitely.
     function setSlashRevealWindowTime(uint256 _slashRevealWindowTime) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/status-network-contracts/test/RLN.t.sol
+++ b/status-network-contracts/test/RLN.t.sol
@@ -171,54 +171,7 @@ contract RLNTest is Test {
         vm.stopPrank();
     }
 
-    /* ---------- SLASH ---------- */
-
-    function test_slash_succeeds() public {
-        uint256 distributorBalance = 50 ether;
-        vm.startPrank(owner);
-        karma.mint(address(distributor1), distributorBalance); // Mint Karma tokens to distributor1
-        distributor1.setUserKarmaShare(user2Addr, 10 ether);
-        vm.stopPrank();
-
-        // Register the identity first
-        vm.startPrank(registerAddr);
-        rln.register(identityCommitment1, user2Addr);
-        vm.stopPrank();
-
-        // Retrieve the assigned index
-        (, uint256 index1) = _memberData(identityCommitment1);
-
-        // burn event
-        vm.expectEmit(true, true, true, true);
-        emit IERC20Upgradeable.Transfer(user2Addr, address(0), 5 ether);
-
-        // reward mint event
-        vm.expectEmit(true, true, true, true);
-        emit IERC20Upgradeable.Transfer(address(0), rewardRecipientAddr, 0.5 ether);
-
-        // slash event
-        vm.expectEmit(true, true, true, true);
-        emit RLN.MemberSlashed(index1, slasherAddr);
-
-        vm.prank(slasherAddr);
-        rln.slash(privateKey1, rewardRecipientAddr);
-
-        // After slash, the member record should be cleared
-        (address u1, uint256 i1) = _memberData(identityCommitment1);
-        assertEq(u1, address(0));
-        assertEq(i1, 0);
-    }
-
-    function test_slash_fails_when_not_registered() public {
-        // Attempt to slash a non‐existent identity
-        vm.startPrank(slasherAddr);
-        vm.expectRevert(RLN.RLN__MemberNotFound.selector);
-        rln.slash(privateKey0, rewardRecipientAddr);
-        vm.stopPrank();
-    }
-
     /* ---------- SLASH COMMIT/REVEAL ---------- */
-
     function test_SlashCommitRevertsIfNoSlashRole() public {
         bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
 

--- a/status-network-contracts/test/RLN.t.sol
+++ b/status-network-contracts/test/RLN.t.sol
@@ -299,6 +299,32 @@ contract RLNTest is Test {
         rln.slashReveal(user1Addr, privateKey0, rewardRecipientAddr);
     }
 
+    function test_SlashRevealRevertsIfAccountIsDifferentFromTheOneUsedDuringCommit() public {
+        vm.startPrank(owner);
+        karma.mint(user1Addr, 10 ether);
+        karma.mint(user2Addr, 10 ether);
+        vm.stopPrank();
+
+        vm.startPrank(registerAddr);
+        rln.register(identityCommitment1, user1Addr);
+        rln.register(identityCommitment2, user2Addr);
+        vm.stopPrank();
+
+        // commit slash for pk1 and user1
+        bytes32 hash1 = keccak256(abi.encodePacked(privateKey1, rewardRecipientAddr));
+        vm.prank(slasherAddr);
+        rln.slashCommit(user1Addr, hash1);
+
+        // malicious commit trying to slash pk1 using the empty queue of user2
+        vm.prank(slasherAddr);
+        rln.slashCommit(user2Addr, hash1);
+
+        // Attempt to reveal pk1 using queue for user2, so we skip the first commit in the queue
+        vm.expectRevert(RLN.RLN__InvalidCommitment.selector);
+        vm.prank(slasherAddr);
+        rln.slashReveal(user2Addr, privateKey1, rewardRecipientAddr);
+    }
+
     function test_SlashCommitCreatesQueueForMultipleCommits() public {
         // Commit three slashes for the same account
         bytes32 hash1 = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));

--- a/status-network-contracts/test/RLN.t.sol
+++ b/status-network-contracts/test/RLN.t.sol
@@ -190,6 +190,7 @@ contract RLNTest is Test {
 
     function test_SlashCommitAddsNewHashWithSlashRole() public {
         bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        bytes32 key = keccak256(abi.encodePacked(slasherAddr, hash));
 
         // Verify commitment doesn't exist yet
         assertEq(rln.slashCommitments(user1Addr, hash), 0);
@@ -199,7 +200,7 @@ contract RLNTest is Test {
         rln.slashCommit(user1Addr, hash);
 
         // Verify commitment was added with a revealStartTime
-        assertGt(rln.slashCommitments(user1Addr, hash), 0);
+        assertGt(rln.slashCommitments(user1Addr, key), 0);
 
         // Verify lastRevealStartTime was updated
         assertGt(rln.lastRevealStartTime(user1Addr), 0);
@@ -238,11 +239,13 @@ contract RLNTest is Test {
 
         // Commit the slash
         bytes32 hash = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        bytes32 key = keccak256(abi.encodePacked(slasherAddr, hash));
+
         vm.prank(slasherAddr);
         rln.slashCommit(user1Addr, hash);
 
         // Verify commitment exists with a revealStartTime
-        uint256 revealStartTime = rln.slashCommitments(user1Addr, hash);
+        uint256 revealStartTime = rln.slashCommitments(user1Addr, key);
         assertGt(revealStartTime, 0);
 
         // Warp time to allow reveal (skip to the reveal window)
@@ -265,7 +268,7 @@ contract RLNTest is Test {
         rln.slashReveal(user1Addr, privateKey0, rewardRecipientAddr);
 
         // Verify commitment was removed
-        assertEq(rln.slashCommitments(user1Addr, hash), 0);
+        assertEq(rln.slashCommitments(user1Addr, key), 0);
 
         // Verify member was slashed
         (address userAddress, uint256 userIndex) = _memberData(identityCommitment0);
@@ -299,18 +302,23 @@ contract RLNTest is Test {
     function test_SlashCommitCreatesQueueForMultipleCommits() public {
         // Commit three slashes for the same account
         bytes32 hash1 = keccak256(abi.encodePacked(privateKey0, rewardRecipientAddr));
+        bytes32 key1 = keccak256(abi.encodePacked(slasherAddr, hash1));
+
         bytes32 hash2 = keccak256(abi.encodePacked(privateKey1, rewardRecipientAddr));
+        bytes32 key2 = keccak256(abi.encodePacked(slasherAddr, hash2));
+
         bytes32 hash3 = keccak256(abi.encodePacked(privateKey2, rewardRecipientAddr));
+        bytes32 key3 = keccak256(abi.encodePacked(slasherAddr, hash3));
 
         vm.startPrank(slasherAddr);
         rln.slashCommit(user1Addr, hash1);
-        uint256 revealTime1 = rln.slashCommitments(user1Addr, hash1);
+        uint256 revealTime1 = rln.slashCommitments(user1Addr, key1);
 
         rln.slashCommit(user1Addr, hash2);
-        uint256 revealTime2 = rln.slashCommitments(user1Addr, hash2);
+        uint256 revealTime2 = rln.slashCommitments(user1Addr, key2);
 
         rln.slashCommit(user1Addr, hash3);
-        uint256 revealTime3 = rln.slashCommitments(user1Addr, hash3);
+        uint256 revealTime3 = rln.slashCommitments(user1Addr, key3);
         vm.stopPrank();
 
         // Verify that each subsequent commit has a later reveal time


### PR DESCRIPTION
This PR implements issue(s) #83 #81 #80 

### Checklist

* check that the slashed account is the same of the one used in the commitment phase
* fix doc comment
* use the slasher address to compute the slash commitment id
* make the slash function internal to avoid front-running