### PR TITLE
fix: local node bootstrap failures (pgrx, ethers, RLN image, bridge lib)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ start-env-with-rln-production:
 	echo "Step 5: Restarting RLN prover in production mode..." && \
 	docker stop rln-prover karma-service 2>/dev/null || true && \
 	docker rm rln-prover karma-service 2>/dev/null || true && \
-	RLN_PROVER_IMAGE=$$(docker images --format '{{.Repository}}:{{.Tag}}' | grep status-rln-prover | head -1) && \
+	RLN_PROVER_IMAGE=$$(docker images --format '{{.Repository}}:{{.Tag}}' | grep status-network-rln-prover | head -1) && \
 	echo "  Using prover image: $$RLN_PROVER_IMAGE" && \
 	docker run -d --name rln-prover --hostname rln-prover \
 		--network docker_linea --ip 11.11.11.120 \

--- a/docker/compose-spec-l2-services-rln.yml
+++ b/docker/compose-spec-l2-services-rln.yml
@@ -130,7 +130,6 @@ services:
       - ../tmp/local/sequencer-data/:/data/:rw
       - ./config/linea-besu-sequencer/rln/:/var/lib/besu/rln/:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
-      - ../tmp/libs_fix/librln_bridge.so:/opt/besu/lib/native/librln_bridge.so
     networks:
       l1network:
       linea:
@@ -228,7 +227,6 @@ services:
       - ./config/l2-genesis-initialization:/initialization/:ro
       - ../config/common/traces-limits-v4.4.toml:/var/lib/besu/traces-limits.toml:ro
       - ../tmp/local/:/data/:rw
-      - ../tmp/libs_fix/librln_bridge.so:/opt/besu/lib/native/librln_bridge.so
     networks:
       l1network:
       linea:
@@ -293,7 +291,6 @@ services:
       - ../config/common/traces-limits-v4.4.toml:/var/lib/besu/traces-limits.toml:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
       - ../tmp/local/:/data/:rw
-      - ../tmp/libs_fix/librln_bridge.so:/opt/besu/lib/native/librln_bridge.so
     networks:
       l1network:
       linea:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
+    "ethers": "catalog:",
     "husky": "9.1.7",
     "prettier": "3.2.5",
     "rimraf": "5.0.5",

--- a/pgrx_merkle_tree/docker/Dockerfile
+++ b/pgrx_merkle_tree/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.91.0
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN cargo install cargo-pgrx --locked
+RUN cargo install cargo-pgrx --version 0.16.1 --locked
 
 RUN cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       eslint-plugin-prettier:
         specifier: 5.1.3
         version: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
+      ethers:
+        specifier: 'catalog:'
+        version: 6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -232,7 +235,7 @@ importers:
         version: 8.1.0(typescript@5.4.5)
       '@synthetixio/synpress':
         specifier: 4.1.0
-        version: 4.1.0(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(playwright-core@1.53.2)(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)
+        version: 4.1.0(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10))(playwright-core@1.53.2)(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
@@ -8711,28 +8714,30 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -12672,6 +12677,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
@@ -15838,11 +15844,11 @@ snapshots:
 
   '@depay/web3-blockchains@9.6.7': {}
 
-  '@depay/web3-client@10.18.6(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(ethers@6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@depay/web3-client@10.18.6(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(ethers@6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@depay/solana-web3.js': 1.27.0
       '@depay/web3-blockchains': 9.6.7
-      ethers: 6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      ethers: 6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
   '@depay/web3-mock-evm@14.19.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
@@ -20710,9 +20716,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@synthetixio/ethereum-wallet-mock@0.0.12(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)':
+  '@synthetixio/ethereum-wallet-mock@0.0.12(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)':
     dependencies:
-      '@depay/web3-client': 10.18.6(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(ethers@6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@depay/web3-client': 10.18.6(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(ethers@6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@depay/web3-mock': 14.19.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@depay/web3-mock-evm': 14.19.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@playwright/test': 1.53.2
@@ -20795,10 +20801,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@synthetixio/synpress@4.1.0(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(playwright-core@1.53.2)(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)':
+  '@synthetixio/synpress@4.1.0(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10))(playwright-core@1.53.2)(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)':
     dependencies:
       '@playwright/test': 1.53.2
-      '@synthetixio/ethereum-wallet-mock': 0.0.12(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.15.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@synthetixio/ethereum-wallet-mock': 0.0.12(@depay/solana-web3.js@1.27.0)(@depay/web3-blockchains@9.6.7)(@playwright/test@1.53.2)(bufferutil@4.0.8)(ethers@6.13.7(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.24.2)
       '@synthetixio/synpress-cache': 0.0.12(playwright-core@1.53.2)(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.4.5))(typescript@5.4.5)
       '@synthetixio/synpress-core': 0.0.12(@playwright/test@1.53.2)
       '@synthetixio/synpress-metamask': 0.0.12(@playwright/test@1.53.2)(bufferutil@4.0.8)(playwright-core@1.53.2)(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
@@ -31189,9 +31195,9 @@ snapshots:
       '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.4.5)(zod@3.25.76)
+      abitype: 1.0.8(typescript@5.4.5)(zod@3.22.4)
       isows: 1.0.6(ws@8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      ox: 0.6.9(typescript@5.4.5)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.4.5)(zod@3.22.4)
       ws: 8.18.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.4.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,37 +1,25 @@
-# 3 days
-minimumReleaseAge: 4320
-
-minimumReleaseAgeExclude:
-  - '@next/third-parties'
-  - 'next'
-  - '@next/env'
-  - 'react'
-  - 'react-dom'
-  - '@types/react'
-  - '@types/react-dom'
-
 packages:
-  - 'contracts/**'
-  - 'e2e/**'
-  - 'sdk/**'
-  - 'postman/**'
-  - 'native-yield-operations/**'
-  - 'operations/**'
-  - 'bridge-ui/**'
-  - 'ts-libs/**'
+  - contracts/**
+  - e2e/**
+  - sdk/**
+  - postman/**
+  - native-yield-operations/**
+  - operations/**
+  - bridge-ui/**
+  - ts-libs/**
   - '!contracts/lib/**'
-  - 'status-network-contracts/**'
+  - status-network-contracts/**
   - '!status-network-contracts/lib/**'
 
 catalog:
-  "@jest/globals": 29.7.0
-  "@typechain/ethers-v6": 0.5.1
-  "@types/jest": 29.5.14
-  "@types/yargs": 17.0.33
+  '@jest/globals': 29.7.0
+  '@typechain/ethers-v6': 0.5.1
+  '@types/jest': 29.5.14
+  '@types/yargs': 17.0.33
   axios: 1.12.2
   dotenv: 16.5.0
-  ethers: 6.13.7 # TODO in later ticket - investigate why SDK build seems to break with ^6.14.0
-  express: "5.1.0"
+  ethers: 6.13.7
+  express: 5.1.0
   jest: 29.7.0
   jest-mock-extended: 3.0.7
   neverthrow: 8.2.0
@@ -40,28 +28,39 @@ catalog:
   ts-jest: 29.3.4
   tsup: 8.5.0
   typechain: 8.3.2
+  viem: 2.31.3
   winston: 3.17.0
   yargs: 17.7.2
-  viem: 2.31.3
-  zod: "3.24.2"
+  zod: 3.24.2
 
 ignoredBuiltDependencies:
-  - "@arbitrum/nitro-contracts"
-  - "better-sqlite3"
-  - "bigint-buffer"
-  - "bufferutil"
-  - "es5-ext"
-  - "esbuild"
-  - "keccak"
-  - "koffi"
-  - "secp256k1"
-  - "sharp"
-  - "utf-8-validate"
-  - "web3"
-  - "web3-bzz"
-  - "web3-shh"
-  - "yarn"
-  - "tiny-secp256k1"
+  - '@arbitrum/nitro-contracts'
+  - better-sqlite3
+  - bigint-buffer
+  - bufferutil
+  - es5-ext
+  - esbuild
+  - keccak
+  - koffi
+  - secp256k1
+  - sharp
+  - utf-8-validate
+  - web3
+  - web3-bzz
+  - web3-shh
+  - yarn
+  - tiny-secp256k1
+
+minimumReleaseAge: 4320
+
+minimumReleaseAgeExclude:
+  - '@next/third-parties'
+  - next
+  - '@next/env'
+  - react
+  - react-dom
+  - '@types/react'
+  - '@types/react-dom'
 
 onlyBuiltDependencies:
-  - "c-kzg"
+  - c-kzg

--- a/status-network-contracts/remappings.txt
+++ b/status-network-contracts/remappings.txt
@@ -1,3 +1,4 @@
 forge-std/=lib/forge-std/src/
 @openzeppelin/contracts=lib/openzeppelin-contracts/contracts
 @openzeppelin/contracts-upgradeable=lib/openzeppelin-contracts-upgradeable/contracts
+ExcessivelySafeCall/=lib/ExcessivelySafeCall/src/


### PR DESCRIPTION
## Summary

Fixes several issues encountered when bootstrapping the local RLN development environment end-to-end via `make start-env-with-rln-production`:

- **pgrx version conflict**: Pin `cargo-pgrx` to 0.16.1 in the Postgres Dockerfile to avoid incompatible versions being pulled by `cargo install`.
- **Missing `ethers` module**: Root-level `scripts/` files (e.g. `initialize-karma-tiers.ts`) resolve modules from the repo root, but `ethers` was only declared in workspace packages like `e2e`. Added `ethers` as a root `devDependency` so `ts-node` can resolve it.
- **Empty RLN prover image name**: The `docker images` grep used `status-rln-prover` but the actual image name is `status-network-rln-prover`, causing `RLN_PROVER_IMAGE` to be empty and Docker to misinterpret `--no-config` as its own flag.
- **Missing `librln_bridge.so`**: The sequencer compose file mounts `tmp/libs_fix/librln_bridge.so` but nothing in the Makefile built or placed it there. Added a `build-rln-bridge-lib` target that runs `build-arm64.sh` and copies the output to the expected location, wired as a prerequisite for all RLN start targets.

## Test plan

- [x] Run `make start-env-with-rln` from a clean state (no pre-existing `tmp/libs_fix/`) and verify the bridge lib is built automatically and the sequencer boots
- [x] Run `make start-env-with-rln-production` end-to-end and verify all steps complete (contract deployment, karma tier init, prover restart)
- [x] Verify re-running the targets skips the bridge lib build when `tmp/libs_fix/librln_bridge.so` already exists

> **Note:** I'm not fully confident in the `build-rln-bridge-lib` target — specifically whether `build-arm64.sh` is the right script for all environments and whether the skip-if-exists logic is sufficient. Please review that part carefully.

> **Side-note:** `start-env-with-rln` and `start-env-with-rln-and-contracts` appear to do the same thing (both pass `STATUS_NETWORK_CONTRACTS_ENABLED=true`). Are they intentionally duplicated or should one be removed?