### PR TITLE
fix: resolve local dev setup issues for clean clone

### DIFF
--- a/docker/compose-spec-l2-services-rln.yml
+++ b/docker/compose-spec-l2-services-rln.yml
@@ -130,7 +130,6 @@ services:
       - ../tmp/local/sequencer-data/:/data/:rw
       - ./config/linea-besu-sequencer/rln/:/var/lib/besu/rln/:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
-      - ../tmp/libs_fix/librln_bridge.so:/opt/besu/lib/native/librln_bridge.so
     networks:
       l1network:
       linea:
@@ -228,7 +227,6 @@ services:
       - ./config/l2-genesis-initialization:/initialization/:ro
       - ../config/common/traces-limits-v4.4.toml:/var/lib/besu/traces-limits.toml:ro
       - ../tmp/local/:/data/:rw
-      - ../tmp/libs_fix/librln_bridge.so:/opt/besu/lib/native/librln_bridge.so
     networks:
       l1network:
       linea:
@@ -293,7 +291,6 @@ services:
       - ../config/common/traces-limits-v4.4.toml:/var/lib/besu/traces-limits.toml:ro
       - ./config/l2-genesis-initialization:/initialization/:ro
       - ../tmp/local/:/data/:rw
-      - ../tmp/libs_fix/librln_bridge.so:/opt/besu/lib/native/librln_bridge.so
     networks:
       l1network:
       linea:

--- a/pgrx_merkle_tree/docker/Dockerfile
+++ b/pgrx_merkle_tree/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.91.0
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN cargo install cargo-pgrx --locked
+RUN cargo install cargo-pgrx --version 0.16.1 --locked
 
 RUN cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config
 

--- a/status-network-contracts/remappings.txt
+++ b/status-network-contracts/remappings.txt
@@ -1,3 +1,4 @@
 forge-std/=lib/forge-std/src/
 @openzeppelin/contracts=lib/openzeppelin-contracts/contracts
 @openzeppelin/contracts-upgradeable=lib/openzeppelin-contracts-upgradeable/contracts
+ExcessivelySafeCall/=lib/ExcessivelySafeCall/src/


### PR DESCRIPTION
- Pin cargo-pgrx to 0.16.1 to match pgrx dependency in Cargo.toml
- Remove broken librln_bridge.so volume mounts (library already exists in the Docker image)
- Add ExcessivelySafeCall remapping for StakeVault.sol imports