### PR TITLE
ci: multi-arch Docker release workflow on tag push

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,117 @@
+name: Release Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  PROVER_IMAGE: 0xnadeem/status-network-rln-prover
+
+jobs:
+  build-rln-prover:
+    name: Build RLN Prover (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./rln-prover
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.PROVER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests/prover
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/prover/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: prover-digest-${{ matrix.runner }}
+          path: /tmp/digests/prover/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-prover:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build-rln-prover
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests/prover
+          pattern: prover-digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract tag
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest and push
+        working-directory: /tmp/digests/prover
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.PROVER_IMAGE }}:${{ steps.tag.outputs.version }} \
+            -t ${{ env.PROVER_IMAGE }}:latest \
+            $(printf '${{ env.PROVER_IMAGE }}@sha256:%s ' *)
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: merge-prover
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract tag
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.version }}
+          name: ${{ steps.tag.outputs.version }}
+          generate_release_notes: true
+          body: |
+            ## Docker Images
+
+            ```
+            docker pull 0xnadeem/status-network-rln-prover:${{ steps.tag.outputs.version }}
+            ```
+
+            Multi-arch: linux/amd64 + linux/arm64
+
+            **Note:** The Besu sequencer image (`status-network-besu`) requires manual build via `scripts/build-rln-enabled-sequencer-patched.sh` due to the gasless block fix patch.


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that builds and pushes multi-arch Docker images when a version tag is pushed.

**Trigger:** Push a tag like `v1.2.0`

**What it does:**
1. Builds `status-network-rln-prover` on native amd64 and arm64 runners (no QEMU)
2. Creates multi-arch manifest and pushes to Docker Hub as `0xnadeem/status-network-rln-prover:<tag>` + `latest`
3. Creates a GitHub Release with auto-generated release notes

**Required secrets:**
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

**Note:** The Besu sequencer image still requires manual build via `scripts/build-rln-enabled-sequencer-patched.sh` due to the gasless block fix patch from linea-besu source. Will add Besu to the workflow in a follow-up.