### PR TITLE
docs: add encrypted payloads for RPC node blindness

### DIFF
--- a/docs/private-gasless-transactions-prd.md
+++ b/docs/private-gasless-transactions-prd.md
@@ -27,17 +27,22 @@ Not in scope: hiding transaction contents, replacing Karma/RLN, privacy for prem
 | Adversary | Sees | Must NOT learn |
 |-----------|------|----------------|
 | On-chain observer | All txs, all addresses, RLN Merkle tree, contract state | Which mother address owns which ephemeral |
-| RPC / Prover operator (live) | Registration request signatures (transient) | **Known limitation**: can ecrecover mother address from signatures. See [Trust Model](#trust-model). |
+| RPC node operator | Encrypted registration payloads, ephemeral sender address | Mother identity behind the ephemeral |
+| Prover operator (live) | Decrypted registration request (transient) | **Known limitation**: can ecrecover mother address from signatures. See [Trust Model](#trust-model). |
 | Prover database (at rest / compromised) | Ephemeral address, RLN identity, tier, spent nullifier hashes | Mother identity behind the ephemeral |
 | Sequencer operator | Tx payload, ephemeral sender address | Mother identity behind the ephemeral |
 
 ### Trust Model
 
-The registration request contains two ECDSA signatures from the mother's private key. Anyone who sees these signatures can `ecrecover` the mother address. In practice, both the RPC node (which receives the JSON-RPC call) and the prover (which processes it via gRPC) can recover the address. The RPC node and prover are typically run by the same entity.
+The registration request contains two ECDSA signatures from the mother's private key. Anyone who sees these signatures in the clear can `ecrecover` the mother address. To keep the RPC node out of this trust boundary, the wallet encrypts the registration payload with the prover's public key before sending. The RPC node forwards opaque bytes. Only the prover can decrypt and recover the mother address.
 
-Why this is fine:
+The prover's encryption public key is published on-chain so wallets can read it without trusting any off-chain source. The prover holds the corresponding private key. Key rotation is handled by updating the on-chain value and re-deploying the prover with the new key.
 
-1. **The prover already holds every user's RLN identity secret** in the `users.rln_id` column ([`user_db_2.rs:313-321`](../rln-prover/prover/src/user_db_2.rs)). That's the cryptographic secret that gets recovered and slashed during RLN violations. If you don't trust the operator with a transient address, you shouldn't trust them with the permanent secret either.
+This keeps the trust model the same as the current system: you trust the prover operator (who already holds every user's RLN secret in `users.rln_id`), and nobody else. The RPC node is a blind relay for registration requests, same as it is for regular gasless transactions today.
+
+Why trusting the prover operator is fine:
+
+1. **The prover already holds every user's RLN identity secret** ([`user_db_2.rs:313-321`](../rln-prover/prover/src/user_db_2.rs)). That's the cryptographic secret that gets recovered and slashed during RLN violations. If you don't trust the operator with a transient address, you shouldn't trust them with the permanent secret either.
 2. **The link is not persistable without active malice.** A compromised prover database reveals nothing (see [Nullifier Design](#nullifier-design) for why). Only an operator actively logging requests at runtime can capture the mapping.
 3. **There's an upgrade path.** If this trust assumption stops being acceptable at scale, the registration endpoint can be swapped for an on-chain ZK proof flow (see [Upgrade Path](#upgrade-path-to-zk-registration)) without touching any other component.
 
@@ -47,9 +52,9 @@ Why this is fine:
 
 Two paths through the network. **Regular gasless** works exactly as it does today: user has Karma, the prover auto-registers them when they receive it, they transact from their main address. Nothing changes.
 
-**Private gasless** is the new opt-in path. The mother wallet calls a JSON-RPC method on the RPC node, which forwards the request to the prover over the existing whitelisted gRPC channel. The prover checks the mother's Karma balance on-chain, derives the tier, registers the ephemeral's RLN commitment on-chain using the existing `ManagedRLNRegister` + `NonceManager`, and throws away the mother address. The ephemeral then activates (also via JSON-RPC through the RPC node) and transacts normally. From the network's perspective it's just another user with a tier and a quota.
+**Private gasless** is the new opt-in path. The mother wallet reads the prover's public key from on-chain, encrypts its registration request, and sends it as a JSON-RPC call to the RPC node. The RPC node forwards the encrypted blob to the prover over the existing whitelisted gRPC channel. The prover decrypts, checks the mother's Karma balance on-chain, derives the tier, registers the ephemeral's RLN commitment on-chain using the existing `ManagedRLNRegister` + `NonceManager`, and throws away the mother address. The ephemeral then activates (also via encrypted JSON-RPC through the RPC node) and transacts normally. From the network's perspective it's just another user with a tier and a quota.
 
-The wallet never talks to the prover directly. It uses the same RPC node endpoint it already uses for `eth_sendRawTransaction` and `linea_estimateGas`. The RPC node proxies the two new methods to the prover over gRPC, same pattern as `RlnProverForwarderValidator` forwarding `SendTransaction` today.
+The wallet never talks to the prover directly. It uses the same RPC node endpoint it already uses for `eth_sendRawTransaction` and `linea_estimateGas`. The RPC node proxies the two new methods to the prover over gRPC, same pattern as `RlnProverForwarderValidator` forwarding `SendTransaction` today. The RPC node never sees the plaintext registration data.
 
 Three things are different from the regular gasless path:
 
@@ -69,12 +74,12 @@ graph TB
         RLNC["RLN Contract"]
     end
 
-    Mother["Mother Wallet"] -->|"1. JSON-RPC: sn_registerPrivateIdentity"| RPC
-    RPC -->|"gRPC forward<br/>(existing whitelisted channel)"| Prover
+    Mother["Mother Wallet"] -->|"1. sn_registerPrivateIdentity<br/>(encrypted with prover pubkey)"| RPC
+    RPC -->|"gRPC forward<br/>(opaque encrypted blob)"| Prover
     Prover -->|"verify Karma balance"| Karma["Karma Contract"]
     Prover -->|"register(commitment)<br/>via ManagedRLNRegister"| RLNC
 
-    Ephemeral["Ephemeral Wallet"] -->|"2. JSON-RPC: sn_activatePrivateIdentity"| RPC
+    Ephemeral["Ephemeral Wallet"] -->|"2. sn_activatePrivateIdentity<br/>(encrypted with prover pubkey)"| RPC
     Ephemeral -->|"3. Gasless txs (gasPrice=0)"| RPC
 
     RPC -->|"gRPC (SendTransaction, etc.)"| Prover
@@ -86,7 +91,9 @@ graph TB
 
 ## RPC Node Changes
 
-Two new JSON-RPC methods on the RPC node: `sn_registerPrivateIdentity` and `sn_activatePrivateIdentity`. These are thin pass-throughs to the prover, following the same pattern as `RlnProverForwarderValidator` which already forwards transaction data to the prover's `SendTransaction` gRPC endpoint. No business logic in the RPC node. Format validation, gRPC forward, return result.
+Two new JSON-RPC methods on the RPC node: `sn_registerPrivateIdentity` and `sn_activatePrivateIdentity`. These are thin pass-throughs to the prover, following the same pattern as `RlnProverForwarderValidator` which already forwards transaction data to the prover's `SendTransaction` gRPC endpoint.
+
+Both methods accept an encrypted payload (a single hex-encoded blob) and forward it to the prover as-is. The RPC node does not decrypt, parse, or validate the contents. The prover decrypts and returns a success/error response, which the RPC node passes back to the wallet.
 
 Both methods are gated behind the same `--plugin-linea-rpc-gasless-enabled` flag that controls the existing gasless features. They only run on RPC nodes, not the sequencer.
 
@@ -98,22 +105,23 @@ Three changes to the prover. Zero changes to the sequencer or any smart contract
 
 ### 1. New gRPC endpoint: `RegisterPrivateIdentity`
 
-The RPC node forwards the wallet's registration request here. The request carries two ECDSA signatures (one for auth, one for nullifier derivation), the ephemeral's RLN commitment, and the current epoch.
+The RPC node forwards the wallet's encrypted registration payload here. The prover decrypts it with its private key to get the two ECDSA signatures, the ephemeral's RLN commitment, and the current epoch.
 
 Here's what the handler does:
 
-1. `ecrecover` both signatures, verify they recover to the same `mother_address` (in memory only)
-2. Verify the epoch is current
-3. Query `karma_sc.balanceOf(mother_address)` and derive tier from the `tier_limits` table
-4. If tier has 0 quota (no Karma or below minimum), reject
-5. Compute the nullifier from the nullifier signature (see [Nullifier Design](#nullifier-design)) and check it's not already spent
-6. Store the nullifier (not the address, not the signature)
-7. Insert the user into the DB with the commitment, tier, `registration_type='private'`, and `activation_status='pending'`
-8. Queue on-chain registration via `ManagedRLNRegister`: `RLN.register(commitment, derived_address)` where `derived_address` is deterministically derived from the commitment (see [On-chain Registration Address](#on-chain-registration-address))
-9. Discard `mother_address` from memory. Never written to disk, database, or logs.
-10. Return success. On-chain confirmation is handled asynchronously by `ManagedRLNRegister` + `NonceManager` with retry and gas-bumping. If the on-chain registration fails after all retries, the DB entry is rolled back (same pattern as regular registrations in [`karma_sc_listener.rs`](../rln-prover/prover/src/karma_sc_listener.rs)).
+1. Decrypt the payload using the prover's private key
+2. `ecrecover` both signatures, verify they recover to the same `mother_address` (in memory only)
+3. Verify the epoch is current
+4. Query `karma_sc.balanceOf(mother_address)` and derive tier from the `tier_limits` table
+5. If tier has 0 quota (no Karma or below minimum), reject
+6. Compute the nullifier from the nullifier signature (see [Nullifier Design](#nullifier-design)) and check it's not already spent
+7. Store the nullifier (not the address, not the signature)
+8. Insert the user into the DB with the commitment, tier, `registration_type='private'`, and `activation_status='pending'`
+9. Queue on-chain registration via `ManagedRLNRegister`: `RLN.register(commitment, derived_address)` where `derived_address` is deterministically derived from the commitment (see [On-chain Registration Address](#on-chain-registration-address))
+10. Discard `mother_address` from memory. Never written to disk, database, or logs.
+11. Return success. On-chain confirmation is handled asynchronously by `ManagedRLNRegister` + `NonceManager` with retry and gas-bumping. If the on-chain registration fails after all retries, the DB entry is rolled back (same pattern as regular registrations in [`karma_sc_listener.rs`](../rln-prover/prover/src/karma_sc_listener.rs)).
 
-Step ordering matters. We insert into the DB first (step 7) and queue on-chain registration second (step 8). If the on-chain tx fails, we roll back the DB entry. This matches the existing registration pattern where the prover maintains the invariant that either both the DB and the contract have the user, or neither does.
+Step ordering matters. We insert into the DB first (step 8) and queue on-chain registration second (step 9). If the on-chain tx fails, we roll back the DB entry. This matches the existing registration pattern where the prover maintains the invariant that either both the DB and the contract have the user, or neither does.
 
 #### Nullifier Design
 
@@ -139,14 +147,15 @@ One thing worth noting: `balanceOf()` on the Karma contract returns the composit
 
 ### 2. New gRPC endpoint: `ActivatePrivateIdentity`
 
-After on-chain registration confirms, the ephemeral wallet hands its RLN identity secret to the prover (via the RPC node proxy) so the prover can generate proofs on its behalf. The request carries the RLN commitment, the full RLN identity (secret + commitment + rate limit, same shape as the `rln_id` column), and the ephemeral's address.
+After on-chain registration confirms, the ephemeral wallet hands its RLN identity secret to the prover (via encrypted JSON-RPC through the RPC node) so the prover can generate proofs on its behalf. The encrypted payload carries the RLN commitment, the full RLN identity (secret + commitment + rate limit, same shape as the `rln_id` column), and the ephemeral's address.
 
-1. Look up the commitment in the `users` table where `activation_status = 'pending'`
-2. Verify `Poseidon(rln_identity.secret)` matches the commitment. This IS the authentication: only someone who generated the commitment knows the matching secret.
-3. Store the RLN identity, set the address to the ephemeral, set `activation_status = 'active'`
-4. Add to the Merkle tree using `Poseidon(identity_commitment, rate_limit)`, same formula as regular users ([`user_db_2.rs:327`](../rln-prover/prover/src/user_db_2.rs))
-5. Initialize a `tx_counter` row for the ephemeral
-6. From here, `SendTransaction` from this ephemeral triggers normal proof generation
+1. Decrypt the payload using the prover's private key
+2. Look up the commitment in the `users` table where `activation_status = 'pending'`
+3. Verify `Poseidon(rln_identity.secret)` matches the commitment. This IS the authentication: only someone who generated the commitment knows the matching secret.
+4. Store the RLN identity, set the address to the ephemeral, set `activation_status = 'active'`
+5. Add to the Merkle tree using `Poseidon(identity_commitment, rate_limit)`, same formula as regular users ([`user_db_2.rs:327`](../rln-prover/prover/src/user_db_2.rs))
+6. Initialize a `tx_counter` row for the ephemeral
+7. From here, `SendTransaction` from this ephemeral triggers normal proof generation
 
 The prover should enforce a per-commitment attempt limit (e.g., 5 attempts) to prevent spam. Anyone can observe `MemberRegistered` events on-chain and try to activate against pending commitments. Poseidon preimage resistance makes brute-forcing the secret infeasible, but the spam itself wastes prover resources.
 
@@ -181,9 +190,12 @@ sequenceDiagram
     M->>M: Generate RLN identity: (secret, commitment) via keygen()
     M->>M: auth_sig = sign(keccak256(epoch || commitment), motherPrivKey)
     M->>M: null_sig = sign(keccak256("sn_private_reg_nullifier" || epoch), motherPrivKey)
+    M->>M: Read prover public key from on-chain
+    M->>M: Encrypt(auth_sig, null_sig, commitment, epoch) with prover pubkey
 
-    M->>RPC: sn_registerPrivateIdentity(auth_sig, null_sig, commitment, epoch)
-    RPC->>P: gRPC RegisterPrivateIdentity (forward)
+    M->>RPC: sn_registerPrivateIdentity(encrypted_payload)
+    RPC->>P: gRPC forward (opaque blob)
+    P->>P: Decrypt payload with prover private key
     P->>P: ecrecover both sigs → verify same mother_address (memory only)
     P->>KC: balanceOf(mother_address)
     KC-->>P: karmaBalance (composite: tokens + distributor rewards)
@@ -198,9 +210,10 @@ sequenceDiagram
     RPC-->>M: success
 
     Note over M,RPC: Random delay (minutes) to reduce IP correlation
-    M->>RPC: sn_activatePrivateIdentity(commitment, rln_identity, ephemeral_addr)
-    RPC->>P: gRPC ActivatePrivateIdentity (forward)
-    P->>P: Verify Poseidon(rln_identity.secret) == commitment
+    M->>M: Encrypt(commitment, rln_identity, ephemeral_addr) with prover pubkey
+    M->>RPC: sn_activatePrivateIdentity(encrypted_payload)
+    RPC->>P: gRPC forward (opaque blob)
+    P->>P: Decrypt, verify Poseidon(rln_identity.secret) == commitment
     P->>DB: Store rln_identity, address=ephemeral_addr, status='active'
     P->>DB: Add leaf to Merkle tree, init tx_counter
     P-->>RPC: success
@@ -250,11 +263,13 @@ Optional. When a new epoch starts, the mother signs a new registration request w
 
 **Prover DB compromise.** The `users` table has the ephemeral address, RLN identity, tier, and registration type. The nullifiers table has `keccak256(nullifier_signature)`. Neither reveals the mother address. The nullifier is derived from a signature, not from the address itself, so even an attacker who knows all Karma holder addresses can't match them against the nullifier table.
 
+**RPC node as blind relay.** Registration payloads are encrypted with the prover's public key. The RPC node forwards opaque bytes. It can't ecrecover the mother address, can't read the signatures, and can't correlate the registration request with the subsequent activation request (both are encrypted blobs). The RPC node's position in the trust model is unchanged from today: it sees ephemeral transaction traffic but never learns the mother identity.
+
 **Replay attacks on RegisterPrivateIdentity.** The auth signature covers `keccak256(epoch || rln_commitment)`. A replayed request in the same epoch hits the nullifier check. A replayed request targeting a different epoch fails epoch validation. A replayed request with a different commitment fails signature verification.
 
 **Front-running ActivatePrivateIdentity.** Only someone who knows the RLN secret (used to derive the commitment via `keygen()`) can activate. The Poseidon commitment check is the authentication. An attacker who sees the `pending` registration can't activate it without the secret. Per-commitment attempt limits prevent resource exhaustion from spam.
 
-**IP correlation.** The RPC node sees both `sn_registerPrivateIdentity` (from the mother's IP) and `sn_activatePrivateIdentity` (from the ephemeral's IP). If both come from the same IP, the operator can correlate them. The wallet SDK should add a random delay (minutes) between registration and activation. Users can also route activation through a different network path. This is a known limitation, documented in the [Threat Model](#threat-model).
+**IP correlation.** The RPC node sees both `sn_registerPrivateIdentity` and `sn_activatePrivateIdentity` from the same or different IPs. Since both are encrypted, the RPC node can't link them by content. It could still correlate by timing if the same IP calls both methods in sequence. The wallet SDK should add a random delay (minutes) between registration and activation. Users can also route activation through a different network path. This is a known limitation, documented in the [Threat Model](#threat-model).
 
 **Reduced slashing penalty.** Private users lose gasless access when slashed but don't lose Karma. You can't slash Karma you can't attribute. The 24-hour lockout is sufficient since there's nothing to gain from exceeding the rate limit.
 
@@ -264,15 +279,18 @@ Optional. When a new epoch starts, the mother signs a new registration request w
 
 From the wallet's perspective, private gasless transactions require:
 
-1. **Generate an ephemeral Ethereum keypair.** Standard secp256k1 keygen.
-2. **Generate an RLN identity.** A `(secret, commitment)` pair where `commitment = Poseidon(secret)`. This is one Poseidon hash over BN254, not a ZK proof. Requires either a WASM build of [zerokit](https://github.com/vacp2p/zerokit)'s keygen or a JS reimplementation (generate random BN254 scalar, compute one Poseidon hash).
-3. **Sign two messages** with the mother's private key (standard `eth_sign`).
-4. **Call `sn_registerPrivateIdentity`** on the same RPC endpoint the wallet already uses.
-5. **Wait a few minutes** (random delay for IP correlation mitigation).
-6. **Call `sn_activatePrivateIdentity`** on the same RPC endpoint.
-7. **Use the ephemeral** for gasless transactions via `eth_sendRawTransaction` as normal.
+1. **Read the prover's public key** from the on-chain registry (one-time, cacheable).
+2. **Generate an ephemeral Ethereum keypair.** Standard secp256k1 keygen.
+3. **Generate an RLN identity.** A `(secret, commitment)` pair where `commitment = Poseidon(secret)`. This is one Poseidon hash over BN254, not a ZK proof. Requires either a WASM build of [zerokit](https://github.com/vacp2p/zerokit)'s keygen or a JS reimplementation (generate random BN254 scalar, compute one Poseidon hash).
+4. **Sign two messages** with the mother's private key (standard `eth_sign`).
+5. **Encrypt the registration payload** with the prover's public key.
+6. **Call `sn_registerPrivateIdentity`** on the same RPC endpoint the wallet already uses.
+7. **Wait a few minutes** (random delay for IP correlation mitigation).
+8. **Encrypt the activation payload** with the prover's public key.
+9. **Call `sn_activatePrivateIdentity`** on the same RPC endpoint.
+10. **Use the ephemeral** for gasless transactions via `eth_sendRawTransaction` as normal.
 
-No gRPC client needed. No ZK proofs. No new endpoints to discover. The wallet talks to the same RPC node it already talks to.
+No gRPC client needed. No ZK proofs. No new endpoints to discover. The wallet talks to the same RPC node it already talks to. The encryption is a standard asymmetric encrypt (ECIES or NaCl box) with a public key read from on-chain.
 
 ---
 
@@ -280,13 +298,14 @@ No gRPC client needed. No ZK proofs. No new endpoints to discover. The wallet ta
 
 ### Phase 1: Build + Deploy
 
-1. **DB migration**: Add columns to `users`, create nullifier table.
-2. **Prover: `RegisterPrivateIdentity`**: New gRPC endpoint with dual-signature verification, signature-based nullifier, and `ManagedRLNRegister` integration.
-3. **Prover: `ActivatePrivateIdentity`**: New gRPC endpoint with commitment verification, identity storage, Merkle tree insertion, and per-commitment attempt limits.
-4. **Prover: `GetUserTierInfo` dual-path**: Branch on `registration_type`.
-5. **RPC node**: Two new JSON-RPC methods that forward to the prover over the existing gRPC channel. Gate behind `--plugin-linea-rpc-gasless-enabled`. 
-6. **Client**: Wallet SDK or script for generating ephemeral keypairs, producing both signatures, and calling the two new JSON-RPC methods.
-7. **Testing**: E2E test covering private registration, activation, gasless tx, deny list expiry, and ephemeral rotation.
+1. **On-chain**: Publish the prover's encryption public key to a registry contract (or add it to an existing contract).
+2. **DB migration**: Add columns to `users`, create nullifier table.
+3. **Prover: `RegisterPrivateIdentity`**: New gRPC endpoint with payload decryption, dual-signature verification, signature-based nullifier, and `ManagedRLNRegister` integration.
+4. **Prover: `ActivatePrivateIdentity`**: New gRPC endpoint with payload decryption, commitment verification, identity storage, Merkle tree insertion, and per-commitment attempt limits.
+5. **Prover: `GetUserTierInfo` dual-path**: Branch on `registration_type`.
+6. **RPC node**: Two new JSON-RPC methods that forward encrypted blobs to the prover over the existing gRPC channel. Gate behind `--plugin-linea-rpc-gasless-enabled`.
+7. **Client**: Wallet SDK or script for reading the prover's public key, generating ephemeral keypairs, producing both signatures, encrypting payloads, and calling the two new JSON-RPC methods.
+8. **Testing**: E2E test covering private registration, activation, gasless tx, deny list expiry, and ephemeral rotation.
 
 ### Phase 2: Monitor + Iterate
 
@@ -316,4 +335,6 @@ If the prover trust assumption stops being acceptable (the network decentralizes
 
 1. **Pending registration TTL.** How long should a pending registration stay activatable? If the ephemeral never activates, the commitment is registered on-chain but never used. We should add a TTL (maybe 1 epoch) after which unactivated registrations get cleaned up. The on-chain commitment is effectively wasted, but that's a minor cost absorbed by the prover's gas budget.
 
-2. **Registration rate limiting.** The RPC node should rate-limit `sn_registerPrivateIdentity` calls per IP. The nullifier prevents double registration per epoch per mother, but a malicious caller could spam invalid requests (wrong signatures, zero-Karma addresses) to waste prover resources.
+2. **Registration rate limiting.** The RPC node should rate-limit `sn_registerPrivateIdentity` calls per IP. The nullifier prevents double registration per epoch per mother, but a malicious caller could spam invalid requests to waste prover resources (the prover has to decrypt each one before it can reject it).
+
+3. **Encryption scheme.** ECIES (secp256k1-based, same curve the wallet already uses) or NaCl box (X25519 + XSalsa20-Poly1305). ECIES keeps everything on one curve. NaCl box is simpler and has better library support in JS/WASM. Either works, this is an implementation choice.


### PR DESCRIPTION
Registration and activation payloads are now encrypted with the prover's public key (published on-chain). The RPC node forwards opaque bytes and can't ecrecover the mother address. This keeps the trust boundary the same as the current system.
