### PR TITLE
fix: gRPC connection auto-recovery with circuit breaker recovery window

### DIFF
--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaRlnValidatorCliOptions.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaRlnValidatorCliOptions.java
@@ -95,6 +95,14 @@ public class LineaRlnValidatorCliOptions implements LineaCliOptions {
   private long gasKillSwitchPollSeconds =
       LineaRlnValidatorConfiguration.V1_DEFAULT.gasKillSwitchPollSeconds();
 
+  @CommandLine.Option(
+      names = "--plugin-linea-rln-circuit-breaker-recovery-ms",
+      description =
+          "Time in ms before circuit breaker allows retry after consecutive gRPC failures (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private long circuitBreakerRecoveryMs =
+      LineaRlnValidatorConfiguration.V1_DEFAULT.circuitBreakerRecoveryMs();
+
   private LineaRlnValidatorCliOptions() {}
 
   public static LineaRlnValidatorCliOptions create() {
@@ -142,7 +150,8 @@ public class LineaRlnValidatorCliOptions implements LineaCliOptions {
         5000L, // maxBackoffDelayMs (5s — fast reconnect after prover restart)
         Optional.empty(), // rlnJniLibPath (use system path)
         gasKillSwitchFilePath, // gasKillSwitchFilePath
-        gasKillSwitchPollSeconds // gasKillSwitchPollSeconds
+        gasKillSwitchPollSeconds, // gasKillSwitchPollSeconds
+        circuitBreakerRecoveryMs // circuitBreakerRecoveryMs
         );
   }
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaRlnValidatorConfiguration.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaRlnValidatorConfiguration.java
@@ -56,7 +56,8 @@ public record LineaRlnValidatorConfiguration(
     long maxBackoffDelayMs,
     Optional<String> rlnJniLibPath,
     String gasKillSwitchFilePath,
-    long gasKillSwitchPollSeconds)
+    long gasKillSwitchPollSeconds,
+    long circuitBreakerRecoveryMs)
     implements LineaOptionsConfiguration {
 
   public static LineaRlnValidatorConfiguration V1_DEFAULT =
@@ -80,7 +81,8 @@ public record LineaRlnValidatorConfiguration(
           5000L, // maxBackoffDelayMs (5 seconds — fast reconnect after prover restart)
           Optional.empty(), // rlnJniLibPath
           "", // gasKillSwitchFilePath (empty = disabled)
-          5L // gasKillSwitchPollSeconds
+          5L, // gasKillSwitchPollSeconds
+          30_000L // circuitBreakerRecoveryMs (30 seconds)
           );
 
   // Accessor for premium gas price threshold in Wei for convenience (converting from GWei)

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/DenyListManager.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/DenyListManager.java
@@ -22,6 +22,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import net.vac.prover.AddToDenyListReply;
 import net.vac.prover.AddToDenyListRequest;
 import net.vac.prover.Address;
@@ -56,6 +58,12 @@ public class DenyListManager implements Closeable {
 
   // Track if gRPC is available
   private final AtomicBoolean grpcAvailable = new AtomicBoolean(false);
+
+  // Circuit breaker with recovery: prevents hammering dead connections while allowing auto-recovery
+  private static final int CIRCUIT_BREAKER_THRESHOLD = 5;
+  private static final long CIRCUIT_BREAKER_RECOVERY_MS = 30_000; // 30 seconds
+  private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+  private final AtomicLong lastFailureTime = new AtomicLong(0);
 
   /**
    * Creates a new DenyListManager with gRPC backend.
@@ -117,6 +125,12 @@ public class DenyListManager implements Closeable {
         channelBuilder.usePlaintext();
       }
 
+      // HTTP/2 keepalive: detect dead connections and trigger automatic reconnection
+      channelBuilder
+          .keepAliveTime(30, TimeUnit.SECONDS)
+          .keepAliveTimeout(10, TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(true);
+
       this.channel = channelBuilder.build();
       this.blockingStub = RlnProverGrpc.newBlockingStub(channel);
       this.grpcAvailable.set(true);
@@ -137,25 +151,25 @@ public class DenyListManager implements Closeable {
    * @return true if the address is denied, false otherwise
    */
   public boolean isDenied(org.hyperledger.besu.datatypes.Address address) {
-    if (blockingStub != null) {
+    if (blockingStub != null && !isCircuitBreakerOpen()) {
       try {
         IsDeniedRequest request =
             IsDeniedRequest.newBuilder().setAddress(toProtoAddress(address)).build();
 
         IsDeniedReply reply = blockingStub.isDenied(request);
-        grpcAvailable.set(true); // Mark available on success
+        recordSuccess();
         return reply.getIsDenied();
       } catch (StatusRuntimeException e) {
         LOG.warn(
-            "{}: gRPC isDenied call failed for {}: {}. Failing open (will retry next call).",
+            "{}: gRPC isDenied call failed for {}: {}. Failing open.",
             serviceName,
             address.toHexString(),
             e.getStatus());
-        grpcAvailable.set(false);
+        recordFailure();
       }
     }
 
-    // Fail open when gRPC unavailable
+    // Fail open when gRPC unavailable or circuit breaker open
     return false;
   }
 
@@ -177,7 +191,7 @@ public class DenyListManager implements Closeable {
    * @return true if the address was newly added, false if gRPC unavailable or already present
    */
   public boolean addToDenyList(org.hyperledger.besu.datatypes.Address address, String reason) {
-    if (blockingStub != null) {
+    if (blockingStub != null && !isCircuitBreakerOpen()) {
       try {
         AddToDenyListRequest.Builder requestBuilder =
             AddToDenyListRequest.newBuilder().setAddress(toProtoAddress(address));
@@ -187,7 +201,7 @@ public class DenyListManager implements Closeable {
         }
 
         AddToDenyListReply reply = blockingStub.addToDenyList(requestBuilder.build());
-        grpcAvailable.set(true);
+        recordSuccess();
 
         LOG.info(
             "{}: Address {} {} deny list via gRPC (reason: {})",
@@ -203,7 +217,7 @@ public class DenyListManager implements Closeable {
             serviceName,
             address.toHexString(),
             e.getStatus());
-        grpcAvailable.set(false);
+        recordFailure();
       }
     }
 
@@ -217,13 +231,13 @@ public class DenyListManager implements Closeable {
    * @return true if the address was removed, false if it wasn't on the list
    */
   public boolean removeFromDenyList(org.hyperledger.besu.datatypes.Address address) {
-    if (blockingStub != null) {
+    if (blockingStub != null && !isCircuitBreakerOpen()) {
       try {
         RemoveFromDenyListRequest request =
             RemoveFromDenyListRequest.newBuilder().setAddress(toProtoAddress(address)).build();
 
         RemoveFromDenyListReply reply = blockingStub.removeFromDenyList(request);
-        grpcAvailable.set(true);
+        recordSuccess();
 
         LOG.info(
             "{}: Address {} {} from deny list via gRPC",
@@ -238,7 +252,7 @@ public class DenyListManager implements Closeable {
             serviceName,
             address.toHexString(),
             e.getStatus());
-        grpcAvailable.set(false);
+        recordFailure();
       }
     }
 
@@ -255,7 +269,7 @@ public class DenyListManager implements Closeable {
    * @return true if the address was removed, false if it wasn't on the list
    */
   public boolean removeFromDenyListAndResetQuota(org.hyperledger.besu.datatypes.Address address) {
-    if (blockingStub != null) {
+    if (blockingStub != null && !isCircuitBreakerOpen()) {
       try {
         RemoveFromDenyListRequest request =
             RemoveFromDenyListRequest.newBuilder()
@@ -264,7 +278,7 @@ public class DenyListManager implements Closeable {
                 .build();
 
         RemoveFromDenyListReply reply = blockingStub.removeFromDenyList(request);
-        grpcAvailable.set(true);
+        recordSuccess();
 
         LOG.info(
             "{}: Address {} {} from deny list via gRPC (with epoch counter reset)",
@@ -279,7 +293,7 @@ public class DenyListManager implements Closeable {
             serviceName,
             address.toHexString(),
             e.getStatus());
-        grpcAvailable.set(false);
+        recordFailure();
       }
     }
 
@@ -293,6 +307,41 @@ public class DenyListManager implements Closeable {
    */
   public boolean isGrpcAvailable() {
     return grpcAvailable.get();
+  }
+
+  private boolean isCircuitBreakerOpen() {
+    int failures = consecutiveFailures.get();
+    if (failures < CIRCUIT_BREAKER_THRESHOLD) {
+      return false;
+    }
+    long elapsed = System.currentTimeMillis() - lastFailureTime.get();
+    if (elapsed > CIRCUIT_BREAKER_RECOVERY_MS) {
+      LOG.info(
+          "{}: Circuit breaker recovery window passed ({} ms), allowing retry",
+          serviceName,
+          elapsed);
+      consecutiveFailures.set(0);
+      return false;
+    }
+    return true;
+  }
+
+  private void recordSuccess() {
+    consecutiveFailures.set(0);
+    grpcAvailable.set(true);
+  }
+
+  private void recordFailure() {
+    int failures = consecutiveFailures.incrementAndGet();
+    lastFailureTime.set(System.currentTimeMillis());
+    grpcAvailable.set(false);
+    if (failures == CIRCUIT_BREAKER_THRESHOLD) {
+      LOG.warn(
+          "{}: Circuit breaker opened after {} consecutive failures. Will auto-recover after {} ms.",
+          serviceName,
+          failures,
+          CIRCUIT_BREAKER_RECOVERY_MS);
+    }
   }
 
   /**

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/KarmaServiceClient.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/KarmaServiceClient.java
@@ -132,6 +132,12 @@ public class KarmaServiceClient implements Closeable {
         channelBuilder.usePlaintext();
       }
 
+      // HTTP/2 keepalive: detect dead connections and trigger automatic reconnection
+      channelBuilder
+          .keepAliveTime(30, TimeUnit.SECONDS)
+          .keepAliveTimeout(10, TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(true);
+
       this.channel = channelBuilder.build();
     }
 

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/NullifierTracker.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/NullifierTracker.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import net.vac.prover.CheckAndRecordNullifierReply;
 import net.vac.prover.CheckAndRecordNullifierRequest;
@@ -68,7 +69,12 @@ public class NullifierTracker implements Closeable {
   private ManagedChannel channel;
   private RlnProverGrpc.RlnProverBlockingStub blockingStub;
   private final AtomicBoolean grpcAvailable = new AtomicBoolean(false);
-  private final AtomicBoolean reconnectScheduled = new AtomicBoolean(false);
+
+  // Circuit breaker with recovery: prevents hammering dead connections while allowing auto-recovery
+  private static final int CIRCUIT_BREAKER_THRESHOLD = 5;
+  private static final long CIRCUIT_BREAKER_RECOVERY_MS = 30_000; // 30 seconds
+  private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+  private final AtomicLong lastFailureTimestamp = new AtomicLong(0);
 
   // gRPC configuration
   private final String grpcHost;
@@ -174,6 +180,12 @@ public class NullifierTracker implements Closeable {
         channelBuilder.usePlaintext();
       }
 
+      // HTTP/2 keepalive: detect dead connections and trigger automatic reconnection
+      channelBuilder
+          .keepAliveTime(30, TimeUnit.SECONDS)
+          .keepAliveTimeout(10, TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(true);
+
       this.channel = channelBuilder.build();
       this.blockingStub = RlnProverGrpc.newBlockingStub(channel);
       this.grpcAvailable.set(true);
@@ -226,7 +238,7 @@ public class NullifierTracker implements Closeable {
     }
 
     // Cold path: Check and record in database via gRPC
-    if (grpcAvailable.get() && blockingStub != null) {
+    if (blockingStub != null && !isCircuitBreakerOpen()) {
       try {
         byte[] nullifierBytes = Bytes.fromHexString(normalizedNullifier).toArrayUnsafe();
         long epoch = parseEpoch(normalizedEpoch);
@@ -238,6 +250,7 @@ public class NullifierTracker implements Closeable {
                 .build();
 
         CheckAndRecordNullifierReply reply = blockingStub.checkAndRecordNullifier(request);
+        recordGrpcSuccess();
 
         if (reply.getIsValid()) {
           // New nullifier - add to local cache
@@ -254,8 +267,7 @@ public class NullifierTracker implements Closeable {
       } catch (StatusRuntimeException e) {
         grpcFailures.incrementAndGet();
         LOG.error("{}: gRPC call failed: {}. Using cache-only mode.", serviceName, e.getStatus());
-        grpcAvailable.set(false);
-        scheduleGrpcReconnect();
+        recordGrpcFailure();
         // Fall through to cache-only behavior
       } catch (IllegalArgumentException e) {
         LOG.error("{}: Invalid nullifier format: {}", serviceName, e.getMessage());
@@ -309,27 +321,39 @@ public class NullifierTracker implements Closeable {
     }
   }
 
-  private void scheduleGrpcReconnect() {
-    // Guard: only allow one reconnect thread at a time
-    if (!reconnectScheduled.compareAndSet(false, true)) {
-      return;
+  private boolean isCircuitBreakerOpen() {
+    int failures = consecutiveFailures.get();
+    if (failures < CIRCUIT_BREAKER_THRESHOLD) {
+      return false;
     }
-    Thread reconnectThread =
-        new Thread(
-            () -> {
-              try {
-                Thread.sleep(30000); // 30 second delay
-                LOG.info("{}: Attempting gRPC reconnection...", serviceName);
-                initializeGrpcClient();
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-              } finally {
-                reconnectScheduled.set(false);
-              }
-            });
-    reconnectThread.setDaemon(true);
-    reconnectThread.setName(serviceName + "-NullifierGrpcReconnect");
-    reconnectThread.start();
+    long elapsed = System.currentTimeMillis() - lastFailureTimestamp.get();
+    if (elapsed > CIRCUIT_BREAKER_RECOVERY_MS) {
+      LOG.info(
+          "{}: Circuit breaker recovery window passed ({} ms), allowing retry",
+          serviceName,
+          elapsed);
+      consecutiveFailures.set(0);
+      return false;
+    }
+    return true;
+  }
+
+  private void recordGrpcSuccess() {
+    consecutiveFailures.set(0);
+    grpcAvailable.set(true);
+  }
+
+  private void recordGrpcFailure() {
+    int failures = consecutiveFailures.incrementAndGet();
+    lastFailureTimestamp.set(System.currentTimeMillis());
+    grpcAvailable.set(false);
+    if (failures == CIRCUIT_BREAKER_THRESHOLD) {
+      LOG.warn(
+          "{}: Circuit breaker opened after {} consecutive failures. Will auto-recover after {} ms.",
+          serviceName,
+          failures,
+          CIRCUIT_BREAKER_RECOVERY_MS);
+    }
   }
 
   /**

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/SharedServiceManager.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/shared/SharedServiceManager.java
@@ -122,6 +122,11 @@ public class SharedServiceManager implements Closeable {
       } else {
         karmaChannelBuilder.usePlaintext();
       }
+      // HTTP/2 keepalive: detect dead connections and trigger automatic reconnection
+      karmaChannelBuilder
+          .keepAliveTime(30, TimeUnit.SECONDS)
+          .keepAliveTimeout(10, TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(true);
       this.sharedKarmaChannel = karmaChannelBuilder.build();
 
       // Initialize KarmaServiceClient with shared channel

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidator.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidator.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import net.consensys.linea.config.GasKillSwitchMonitor;
 import net.consensys.linea.config.LineaRlnValidatorConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
@@ -85,6 +86,8 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
 
   // Circuit breaker threshold: reject after this many consecutive gRPC failures
   private static final int CIRCUIT_BREAKER_THRESHOLD = 5;
+  // Circuit breaker recovery: allow a probe request after this many ms since last failure
+  private final long circuitBreakerRecoveryMs;
 
   // Statistics tracking
   private final AtomicInteger validationCallCount = new AtomicInteger(0);
@@ -93,6 +96,7 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
   private final AtomicInteger grpcSuccessCount = new AtomicInteger(0);
   private final AtomicInteger grpcFailureCount = new AtomicInteger(0);
   private final AtomicInteger consecutiveGrpcFailures = new AtomicInteger(0);
+  private final AtomicLong lastGrpcFailureTime = new AtomicLong(0);
 
   // gRPC client components
   private final ManagedChannel channel;
@@ -170,6 +174,8 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
     this.rlnConfig = rlnConfig;
     this.enabled = enabled;
     this.gasKillSwitchMonitor = gasKillSwitchMonitor;
+    this.circuitBreakerRecoveryMs =
+        rlnConfig != null ? rlnConfig.circuitBreakerRecoveryMs() : 30_000L;
     this.transactionSimulationService = transactionSimulationService;
     this.blockchainService = blockchainService;
     this.worldStateService = worldStateService;
@@ -211,6 +217,12 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
     } else {
       channelBuilder.usePlaintext();
     }
+
+    // HTTP/2 keepalive: detect dead connections and trigger automatic reconnection
+    channelBuilder
+        .keepAliveTime(30, TimeUnit.SECONDS)
+        .keepAliveTimeout(10, TimeUnit.SECONDS)
+        .keepAliveWithoutCalls(true);
 
     return channelBuilder.build();
   }
@@ -339,12 +351,23 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
 
     // Circuit breaker: if too many consecutive gRPC failures, reject instead of fail-open
     if (consecutiveGrpcFailures.get() >= CIRCUIT_BREAKER_THRESHOLD) {
-      LOG.error(
-          "Circuit breaker OPEN: {} consecutive gRPC failures. Rejecting tx {} to prevent fail-open.",
-          consecutiveGrpcFailures.get(),
-          transaction.getHash().toHexString());
-      return Optional.of(
-          "RLN prover service unavailable (circuit breaker open). Please try again later.");
+      long timeSinceLastFailure = System.currentTimeMillis() - lastGrpcFailureTime.get();
+      if (timeSinceLastFailure > circuitBreakerRecoveryMs) {
+        LOG.info(
+            "Circuit breaker recovery window passed ({} ms since last failure), resetting and allowing probe request for tx {}",
+            timeSinceLastFailure,
+            transaction.getHash().toHexString());
+        consecutiveGrpcFailures.set(0);
+        // Fall through to attempt the gRPC call as a probe
+      } else {
+        LOG.error(
+            "Circuit breaker OPEN: {} consecutive gRPC failures (last failure {} ms ago). Rejecting tx {} to prevent fail-open.",
+            consecutiveGrpcFailures.get(),
+            timeSinceLastFailure,
+            transaction.getHash().toHexString());
+        return Optional.of(
+            "RLN prover service unavailable (circuit breaker open). Please try again later.");
+      }
     }
 
     // Forward to RLN prover
@@ -420,8 +443,10 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
       if (code == Status.Code.RESOURCE_EXHAUSTED
           || code == Status.Code.NOT_FOUND
           || code == Status.Code.INVALID_ARGUMENT
-          || code == Status.Code.PERMISSION_DENIED) {
-        // Intentional rejection by the prover (quota exceeded, unregistered user, bad input)
+          || code == Status.Code.PERMISSION_DENIED
+          || code == Status.Code.ALREADY_EXISTS) {
+        // Intentional rejection by the prover (quota exceeded, unregistered user, bad input,
+        // duplicate tx)
         consecutiveGrpcFailures.set(0); // Not a failure, reset circuit breaker
         LOG.warn(
             "RLN prover rejected transaction {} ({}): {}",
@@ -434,6 +459,7 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
       // Transient gRPC error (UNAVAILABLE, DEADLINE_EXCEEDED, etc.)
       grpcFailureCount.incrementAndGet();
       int failures = consecutiveGrpcFailures.incrementAndGet();
+      lastGrpcFailureTime.set(System.currentTimeMillis());
       LOG.warn(
           "gRPC forwarding failed for transaction {} (consecutive failures: {}, status: {}): {}",
           transaction.getHash(),
@@ -442,8 +468,9 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
           sre.getMessage());
       if (failures >= CIRCUIT_BREAKER_THRESHOLD) {
         LOG.error(
-            "Circuit breaker OPENING after {} consecutive gRPC failures. Subsequent transactions will be rejected.",
-            failures);
+            "Circuit breaker OPENING after {} consecutive gRPC failures. Will auto-recover after {} ms.",
+            failures,
+            circuitBreakerRecoveryMs);
         return Optional.of("RLN prover service unavailable. Please try again later.");
       }
       // Below threshold: graceful fallback - accept the transaction
@@ -452,6 +479,7 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
       // Non-gRPC exceptions (unexpected errors)
       grpcFailureCount.incrementAndGet();
       int failures = consecutiveGrpcFailures.incrementAndGet();
+      lastGrpcFailureTime.set(System.currentTimeMillis());
       LOG.warn(
           "gRPC forwarding failed for transaction {} (consecutive failures: {}): {}",
           transaction.getHash(),
@@ -459,8 +487,9 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
           e.getMessage());
       if (failures >= CIRCUIT_BREAKER_THRESHOLD) {
         LOG.error(
-            "Circuit breaker OPENING after {} consecutive gRPC failures. Subsequent transactions will be rejected.",
-            failures);
+            "Circuit breaker OPENING after {} consecutive gRPC failures. Will auto-recover after {} ms.",
+            failures,
+            circuitBreakerRecoveryMs);
         return Optional.of("RLN prover service unavailable. Please try again later.");
       }
       // Below threshold: graceful fallback - accept the transaction

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnVerifierValidator.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnVerifierValidator.java
@@ -321,6 +321,13 @@ public class RlnVerifierValidator implements PluginTransactionPoolValidator, Clo
       } else {
         channelBuilder.usePlaintext();
       }
+
+      // HTTP/2 keepalive: detect dead connections and trigger automatic reconnection
+      channelBuilder
+          .keepAliveTime(30, TimeUnit.SECONDS)
+          .keepAliveTimeout(10, TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(true);
+
       this.proofServiceChannel = channelBuilder.build();
     }
 

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidatorAuditFixTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidatorAuditFixTest.java
@@ -96,7 +96,8 @@ class RlnProverForwarderValidatorAuditFixTest {
             30000L,
             Optional.empty(),
             "",
-            5L);
+            5L,
+            30_000L);
 
     validator = new RlnProverForwarderValidator(rlnConfig, true);
   }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidatorMeaningfulTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidatorMeaningfulTest.java
@@ -100,7 +100,8 @@ class RlnProverForwarderValidatorMeaningfulTest {
             30000L,
             Optional.empty(),
             "", // gasKillSwitchFilePath (disabled)
-            5L); // gasKillSwitchPollSeconds
+            5L, // gasKillSwitchPollSeconds
+            30_000L); // circuitBreakerRecoveryMs
 
     // Create both enabled (RPC mode) and disabled (sequencer mode) validators
     enabledValidator = new RlnProverForwarderValidator(rlnConfig, true);

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnValidatorBasicTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnValidatorBasicTest.java
@@ -112,7 +112,8 @@ class RlnValidatorBasicTest {
             30000L, // maxBackoffDelayMs
             Optional.empty(), // rlnJniLibPath
             "", // gasKillSwitchFilePath (disabled)
-            5L // gasKillSwitchPollSeconds
+            5L, // gasKillSwitchPollSeconds
+            30_000L // circuitBreakerRecoveryMs
             );
 
     // Create test transaction
@@ -163,7 +164,8 @@ class RlnValidatorBasicTest {
             30000L,
             Optional.empty(),
             "", // gasKillSwitchFilePath (disabled)
-            5L); // gasKillSwitchPollSeconds
+            5L, // gasKillSwitchPollSeconds
+            30_000L); // circuitBreakerRecoveryMs
 
     RlnVerifierValidator validator =
         new RlnVerifierValidator(

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnVerifierValidatorComprehensiveTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnVerifierValidatorComprehensiveTest.java
@@ -133,7 +133,8 @@ class RlnVerifierValidatorComprehensiveTest {
             30000L,
             Optional.empty(),
             "", // gasKillSwitchFilePath (disabled)
-            5L); // gasKillSwitchPollSeconds
+            5L, // gasKillSwitchPollSeconds
+            30_000L); // circuitBreakerRecoveryMs
 
     validator =
         new RlnVerifierValidator(
@@ -229,7 +230,8 @@ class RlnVerifierValidatorComprehensiveTest {
               30000L,
               Optional.empty(),
               "", // gasKillSwitchFilePath (disabled)
-              5L); // gasKillSwitchPollSeconds
+              5L, // gasKillSwitchPollSeconds
+              30_000L); // circuitBreakerRecoveryMs
 
       assertThat(testConfig).isNotNull();
     }
@@ -262,7 +264,8 @@ class RlnVerifierValidatorComprehensiveTest {
             30000L,
             Optional.empty(),
             "", // gasKillSwitchFilePath (disabled)
-            5L); // gasKillSwitchPollSeconds
+            5L, // gasKillSwitchPollSeconds
+            30_000L); // circuitBreakerRecoveryMs
 
     RlnVerifierValidator disabledValidator =
         new RlnVerifierValidator(
@@ -369,7 +372,8 @@ class RlnVerifierValidatorComprehensiveTest {
             30000L,
             Optional.empty(),
             "", // gasKillSwitchFilePath (disabled)
-            5L); // gasKillSwitchPollSeconds
+            5L, // gasKillSwitchPollSeconds
+            30_000L); // circuitBreakerRecoveryMs
 
     // Test that config is correct
     assertThat(blockConfig).isNotNull();
@@ -588,7 +592,8 @@ class RlnVerifierValidatorComprehensiveTest {
               30000L,
               Optional.empty(),
               "", // gasKillSwitchFilePath (disabled)
-              5L); // gasKillSwitchPollSeconds
+              5L, // gasKillSwitchPollSeconds
+              30_000L); // circuitBreakerRecoveryMs
 
       assertThat(testConfig).isNotNull();
 


### PR DESCRIPTION
- Fix permanent circuit breaker lockout in `RlnProverForwarderValidator`
- Add 30s recovery window so the circuit breaker auto-resets and retries after prover restarts
- Add `ALREADY_EXISTS` to intentional rejection codes (not counted as service failures)
- Add HTTP/2 keepalive (30s ping, 10s timeout) to all 6 `ManagedChannel` instances for early dead connection detection
- Add circuit breaker with recovery to `DenyListManager` and `NullifierTracker` (previously failed silently)
- Remove `NullifierTracker.scheduleGrpcReconnect()` which leaked channels on each reconnect attempt
- Add configurable `--plugin-linea-rln-circuit-breaker-recovery-ms` CLI option (default: 30s)
