### PR TITLE
fix: update deprecated GitHub Actions in CI verify job

### DIFF
--- a/.github/workflows/status-network-ci.yml
+++ b/.github/workflows/status-network-ci.yml
@@ -136,12 +136,12 @@ jobs:
           submodules: recursive
 
       - name: Install Python
-        uses: actions/setup-python@v2
-        with: { python-version: 3.9 }
+        uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
 
       - name: Install Java
-        uses: actions/setup-java@v1
-        with: { java-version: "11", java-package: jre }
+        uses: actions/setup-java@v4
+        with: { distribution: "temurin", java-version: "11" }
 
       - name: Install Certora CLI
         run: pip3 install certora-cli


### PR DESCRIPTION
- Bump `actions/setup-python` from v2 to v5, Python 3.9 → 3.12 (3.9 is EOL and removed from GitHub runners)
- Bump `actions/setup-java` from v1 to v4 with `distribution: temurin` (v1 is deprecated)
