### PR TITLE
Add EpochService2 intial code

### DIFF
--- a/rln-prover/Cargo.lock
+++ b/rln-prover/Cargo.lock
@@ -3841,6 +3841,7 @@ dependencies = [
  "rln_proof",
  "serde",
  "serde_json",
+ "serial_test",
  "smart_contract",
  "sqlx",
  "tempfile",
@@ -4503,6 +4504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,6 +4550,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -4733,6 +4749,32 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/rln-prover/prover/Cargo.toml
+++ b/rln-prover/prover/Cargo.toml
@@ -56,6 +56,7 @@ tempfile = "3.26"
 tracing-test = "0.2"
 lazy_static = "1.5"
 function_name = "0.3"
+serial_test = "3.4.0"
 
 [[bench]]
 name = "prover_bench"

--- a/rln-prover/prover/src/epoch_service.rs
+++ b/rln-prover/prover/src/epoch_service.rs
@@ -226,7 +226,7 @@ impl EpochService {
 pub enum EpochServiceInitError {
     #[error("epoch slice duration is too large (cannot fit in i32) or == 0")]
     EpochSliceDuration,
-    #[error("epoch duration must be > 0 and >= 2 * epoch_slice_duration")]
+    #[error("epoch duration must be > 0")]
     EpochDuration,
     #[error("genesis is in the future")]
     FutureGenesis,

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use tokio::sync::Notify;
 use tracing::{debug, error};
 // Common?
-use crate::epoch_service::{Epoch, EpochServiceInitError, WaitUntilError, DEFAULT_EPOCH_DURATION};
+use crate::epoch_service::{DEFAULT_EPOCH_DURATION, Epoch, EpochServiceInitError, WaitUntilError};
 // Internal
 use crate::error::AppError2;
 use crate::metrics::{
@@ -181,12 +181,8 @@ pub struct EpochService2Config {
 }
 
 impl EpochService2Config {
-
     /// Create config with custom epoch duration
-    pub fn new(
-        epoch_duration: Duration,
-        genesis: DateTime<Utc>,
-    ) -> Self {
+    pub fn new(epoch_duration: Duration, genesis: DateTime<Utc>) -> Self {
         Self {
             epoch_duration,
             genesis,
@@ -216,7 +212,6 @@ impl TryFrom<EpochService2Config> for EpochService2 {
         })
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -215,6 +215,8 @@ impl TryFrom<EpochService2Config> for EpochService2 {
 mod tests {
     use super::*;
     use chrono::{NaiveDate, NaiveDateTime, TimeDelta};
+    use crate::ARGS_DEFAULT_GENESIS;
+    use serial_test::serial;
 
     #[test]
     fn test_compute_current_epoch() {
@@ -364,6 +366,52 @@ mod tests {
             let res = EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now);
             assert!(matches!(res, Err(WaitUntilError::TooLow(_, _))));
         }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_service() {
+
+        let epoch_duration = Duration::from_secs(30);
+        let cfg = EpochService2Config {
+            epoch_duration,
+            genesis: ARGS_DEFAULT_GENESIS,
+        };
+        let epoch_service = EpochService2::try_from(cfg).unwrap();
+        let notifier = epoch_service.epoch_changes.clone();
+
+        let epoch_store = epoch_service.current_epoch.clone();
+        let mut current_epoch = *epoch_service.current_epoch.read();
+
+        // Start epoch service
+        let _ = tokio::task::spawn(async move {
+            epoch_service.listen_for_new_epoch().await
+        });
+
+        let counter_max = 3;
+        let res = tokio::task::spawn(
+            tokio::time::timeout(
+                epoch_duration.checked_mul(counter_max + 1).unwrap(),
+                async move {
+                        let mut counter = 0;
+                        loop {
+                            let res = notifier.notified().await;
+                            counter += 1;
+                            if counter >= counter_max {
+                                break;
+                            }
+
+                            let epoch = *epoch_store.read();
+                            if epoch != current_epoch + 1 && current_epoch != Epoch::from(0) {
+                                panic!("Start with epoch: {:?}, and now in epoch: {:?}, aborting unit test...", current_epoch, epoch);
+                            }
+                            current_epoch = epoch;
+                        }
+                    }
+            )
+        );
+
+        let _res = res.await.unwrap().unwrap();
     }
 
     // Helpers

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -1,0 +1,334 @@
+use std::ops::Add;
+use std::sync::Arc;
+use std::time::Duration;
+use alloy::consensus::BlockHeader;
+use parking_lot::RwLock;
+use tokio::sync::Notify;
+use tracing::{debug, error};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, OutOfRangeError, TimeDelta, Utc};
+use metrics::{gauge, histogram};
+use crate::error::AppError2;
+// Common?
+use crate::epoch_service::{Epoch, WaitUntilError};
+// Internal
+use crate::metrics::{
+    EPOCH_SERVICE_CURRENT_EPOCH, EPOCH_SERVICE_CURRENT_EPOCH_SLICE, EPOCH_SERVICE_DRIFT_MILLIS,
+};
+
+/// Minimum duration returned by EpochService2::compute_wait_until()
+const WAIT_UNTIL_MIN_DURATION: Duration = Duration::from_secs(10);
+/// EpochService::compute_wait_until() can return an error like TooLow (see WAIT_UNTIL_MIN_DURATION)
+/// so the epoch service will retry X many times.
+const WAIT_UNTIL_MAX_RETRY: usize = 10;
+
+pub struct EpochService2 {
+    /// Duration of an epoch (quotas reset every epoch)
+    epoch_duration: Duration,
+    /// Current epoch and epoch slice
+    pub current_epoch: Arc<RwLock<Epoch>>,
+    /// Genesis time (aka when the service has been started at the first time)
+    genesis: DateTime<Utc>,
+    /// Channel to notify when an epoch / epoch slice has just changed
+    pub epoch_changes: Arc<Notify>,
+}
+
+impl EpochService2 {
+    // Note: listen_for_new_epoch never ends so no log will happen with #[instrument]
+    //       + metrics already tracks the current epoch / epoch_slice
+    // #[instrument(skip(self), fields(self.epoch_duration, self.genesis, self.current_epoch))]
+    pub(crate) async fn listen_for_new_epoch(&self) -> Result<(), AppError2> {
+
+        let mut retry_counter = 0;
+        let (current_epoch, mut wait_until) = loop {
+            match EpochService2::compute_wait_until(
+                &self.genesis,
+                &self.epoch_duration,
+                &|| Utc::now(),
+                &|| tokio::time::Instant::now()
+            ) {
+                Ok((current_epoch, wait_until)) => break (current_epoch, wait_until),
+                Err(WaitUntilError::TooLow(d1, d2)) => {
+                    // Wait until is too low (according to const WAIT_UNTIL_MIN_DURATION)
+                    // so we will retry (WAIT_UNTIL_MAX_COMPUTE_ERROR many times) after a short sleep
+                    debug!("compute_wait_until return TooLow, will retry after a sleep...");
+                    tokio::time::sleep(WAIT_UNTIL_MIN_DURATION).await;
+                    retry_counter += 1;
+                    if retry_counter > WAIT_UNTIL_MAX_RETRY {
+                        error!(
+                            "Too many errors while computing the initial wait until time, aborting..."
+                        );
+                        return Err(AppError2::EpochError(WaitUntilError::TooLow(d1, d2)));
+                    }
+                },
+                Err(e) => {
+                    // Another error (like OutOfRange) - exiting...
+                    error!("Error computing the initial wait until: {}", e);
+                    return Err(AppError2::EpochError(e));
+                }
+            }
+        };
+        // Debug
+        // let current_epoch = 0;
+        // let mut wait_until = tokio::time::Instant::now();
+
+        *self.current_epoch.write() = current_epoch.into();
+        debug!(
+            "Initial epoch: {}",
+            current_epoch
+        );
+
+        loop {
+            debug!("wait until: {:?}", wait_until);
+            // XXX: Should we check the drift between now() and wait_until ?
+            tokio::time::sleep_until(wait_until).await;
+            {
+                let now_ = tokio::time::Instant::now();
+                debug!("awake at: {:?}, drift by: {:?}", now_, now_ - wait_until);
+                histogram!(EPOCH_SERVICE_DRIFT_MILLIS.name, "prover" => "epoch service")
+                    .record(now_ - wait_until);
+
+                // Note: could use checked_add() here, but it's quite impossible to have an overflow here
+                //       it would mean that the epoch_slice_duration is insanely large and wait_until
+                //       overflows as a timestamp
+                wait_until += self.epoch_duration;
+
+                *self.current_epoch.write() = current_epoch.into();
+
+                // Note: based on this link https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
+                //       "Casting from an integer to float will produce the closest possible float *"
+                gauge!(EPOCH_SERVICE_CURRENT_EPOCH.name, "prover" => "epoch service")
+                    .set(current_epoch as f64);
+
+                self.epoch_changes.notify_one();
+            }
+        }
+    }
+
+    fn compute_wait_until<T: std::fmt::Debug, F: Fn() -> DateTime<Utc>, TF: Fn() -> T>(
+        genesis: &DateTime<Utc>,
+        epoch_duration: &Duration,
+        now: &F,
+        now2: &TF,
+    ) -> Result<(i64, T), WaitUntilError>
+    where
+        T: Add<Duration, Output = T>,
+    {
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = Self::compute_current_epoch_0(genesis, now, epoch_duration);
+
+        // TODO / FIXME - Troubleshot: weird to use now() & now2() at different time here...
+        // time to wait to next epoch
+        let wait_until_0_ = current_epoch_end_ts - now().timestamp();
+        let wait_until_0 = Duration::from_secs(wait_until_0_ as u64);
+        if wait_until_0 < WAIT_UNTIL_MIN_DURATION {
+            return Err(WaitUntilError::TooLow(wait_until_0, WAIT_UNTIL_MIN_DURATION));
+        }
+
+        let wait_until = now2() + wait_until_0;
+        Ok((current_epoch, wait_until))
+    }
+
+    /// Compute current epoch since genesis
+    /// Return current_epoch AND DateTime of the start & end of this current epoch (as timestamps)
+    fn compute_current_epoch_0<F: Fn() -> DateTime<Utc>>(
+        genesis: &DateTime<Utc>,
+        now: &F,
+        epoch_duration: &Duration,
+    ) -> (i64, i64, i64) {
+
+        debug_assert!(now() > *genesis);
+        debug_assert!(epoch_duration.as_secs() > 0);
+        debug_assert!(i64::try_from(epoch_duration.as_secs()).is_ok());
+
+        let genesis_timestamp = genesis.timestamp();
+        let now_timestamp = now().timestamp();
+        // Get time delta between genesis
+        let diff = now_timestamp - genesis_timestamp;
+        let current_epoch = diff.checked_div(epoch_duration.as_secs() as i64).unwrap();
+
+        let epoch_start = genesis_timestamp + (current_epoch.checked_mul(epoch_duration.as_secs() as i64).unwrap());
+        let epoch_end = genesis_timestamp + ((current_epoch + 1).checked_mul(epoch_duration.as_secs() as i64).unwrap());
+
+        (current_epoch, epoch_start, epoch_end)
+
+    }
+
+    /*
+    /// Compute current epoch since genesis
+    /// Return current_epoch AND DateTime of the start & end of this current epoch
+    fn compute_current_epoch<F: Fn() -> DateTime<Utc>>(
+        genesis: DateTime<Utc>,
+        now: &F,
+        epoch_duration: &Duration,
+    ) -> (i64, DateTime<Utc>, DateTime<Utc>) {
+
+        debug_assert!(now() > genesis);
+        debug_assert!(epoch_duration.as_secs() > 0);
+        debug_assert!(i64::try_from(epoch_duration.as_secs()).is_ok());
+
+
+        let diff = now() - genesis;
+        // Unwrap safe: epoch_duration > 0 + safe to convert to i64
+        let current_epoch = diff.checked_div(epoch_duration.as_secs() as i32).unwrap();
+        let epoch_start = genesis + (current_epoch.checked_mul(epoch_duration.as_secs() as i32).unwrap());
+        let epoch_end = genesis + (current_epoch.checked_mul(epoch_duration.as_secs() as i32 + 1).unwrap());
+
+        (0, epoch_start, epoch_end)
+    }
+    */
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::providers::WatchTxError::Timeout;
+    use super::*;
+    use chrono::{NaiveDate, NaiveDateTime, TimeDelta};
+
+    #[test]
+    fn test_compute_current_epoch() {
+
+        let epoch_duration = Duration::from_hours(1);
+
+        let day_ = 14;
+        let genesis_0_date = NaiveDate::from_ymd_opt(2025, 5, day_).unwrap();
+        let genesis_0: NaiveDateTime = genesis_0_date
+            .and_hms_opt(4, 0, 0)
+            .unwrap();
+        let genesis: DateTime<Utc> =
+            chrono::DateTime::from_naive_utc_and_offset(genesis_0, chrono::Utc);
+
+        let now_f = move || {
+            let now_0: NaiveDateTime = genesis_0_date
+                .and_hms_opt(4+2, 0, 0)
+                .unwrap();
+            let now: DateTime<Utc> =
+                chrono::DateTime::from_naive_utc_and_offset(now_0, chrono::Utc);
+            now
+        };
+
+        // With epoch duration = 1 hour
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(1));
+        assert_eq!(current_epoch, 2);
+        assert_eq!(current_epoch_start_ts, make_utc_datetime(genesis_0_date, 4+2, 0, 0).timestamp());
+        assert_eq!(current_epoch_end_ts, make_utc_datetime(genesis_0_date, 4+3, 0, 0).timestamp());
+
+        // Same but with epoch duration = 2 hours
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(2));
+        assert_eq!(current_epoch, 1);
+        assert_eq!(current_epoch_start_ts, make_utc_datetime(genesis_0_date, 4+2, 0, 0).timestamp());
+        assert_eq!(current_epoch_end_ts, make_utc_datetime(genesis_0_date, 4+4, 0, 0).timestamp());
+
+        // Same but with epoch duration = 15 minutes
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_mins(15));
+        assert_eq!(current_epoch, 8);
+        assert_eq!(current_epoch_start_ts, make_utc_datetime(genesis_0_date, 6, 0, 0).timestamp());
+        assert_eq!(current_epoch_end_ts, make_utc_datetime(genesis_0_date, 6, 15, 0).timestamp());
+    }
+
+    #[test]
+    fn test_compute_current_epoch_2() {
+
+        // Test compute_current_epoch when now() is close to genesis time (expect current_epoch == 0)
+
+        let epoch_duration = Duration::from_hours(1);
+
+        let day_ = 14;
+        let genesis_0: NaiveDateTime = NaiveDate::from_ymd_opt(2025, 5, day_)
+            .unwrap()
+            .and_hms_opt(4, 0, 0)
+            .unwrap();
+        let genesis: DateTime<Utc> =
+            chrono::DateTime::from_naive_utc_and_offset(genesis_0, chrono::Utc);
+
+        let now_f = move || { genesis.checked_add_signed(TimeDelta::new(1, 0).unwrap()).unwrap()  };
+
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(
+            &genesis, &now_f, &Duration::from_hours(1));
+
+        assert_eq!(current_epoch, 0);
+        assert_eq!(current_epoch_start_ts, genesis.timestamp());
+        assert_eq!(current_epoch_end_ts, genesis.timestamp() + epoch_duration.as_secs() as i64);
+    }
+
+    #[test]
+    fn test_wait_until() {
+        // Check wait_until is correctly computed
+
+        let date_0 = NaiveDate::from_ymd_opt(2025, 5, 14).unwrap();
+        let datetime_0 = date_0.and_hms_opt(0, 0, 0).unwrap();
+
+        let genesis: DateTime<Utc> =
+            chrono::DateTime::from_naive_utc_and_offset(datetime_0, Utc);
+
+        {
+            // Check wait_until close to genesis
+            let epoch_duration_ = 45;
+            let epoch_duration = Duration::from_mins(epoch_duration_);
+            let now = || {
+                let t_delta = TimeDelta::minutes(15);
+                genesis.checked_add_signed(t_delta).unwrap()
+            };
+
+            let (current_epoch, wait_until) = EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now).unwrap();
+            assert_eq!(current_epoch, 0);
+            assert_eq!(wait_until, make_utc_datetime(date_0, 0, epoch_duration_ as u32, 0));
+        }
+
+        {
+            // Check wait_until in epoch 1
+
+            let epoch_duration_ = 45;
+            let epoch_duration = Duration::from_mins(epoch_duration_);
+            let now = || {
+                // Now is in epoch 1 + 1s
+                let t_delta = TimeDelta::minutes((epoch_duration_ + 1) as i64);
+                genesis.checked_add_signed(t_delta).unwrap()
+            };
+
+            let (current_epoch, wait_until) = EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now).unwrap();
+            assert_eq!(current_epoch, 1);
+            assert_eq!(wait_until, make_utc_datetime(date_0, 0, (epoch_duration_ * 2) as u32, 0));
+        }
+
+
+        {
+            // Check for WaitUntilError::TooLow
+
+            let epoch_duration = Duration::from_mins(15);
+            let now = || {
+
+                let epoch_duration_minus_1 =
+                    epoch_duration - WAIT_UNTIL_MIN_DURATION + Duration::from_secs(1);
+
+                let as_tdelta = TimeDelta::new(epoch_duration_minus_1.as_secs() as i64, 0).unwrap();
+                genesis.checked_add_signed(as_tdelta).unwrap()
+            };
+
+            let res = EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now);
+            assert!(matches!(res, Err(WaitUntilError::TooLow(_, _))));
+        }
+    }
+
+    fn make_utc_datetime(date: NaiveDate, hours: u32, mins: u32, secs: u32) -> DateTime<Utc> {
+
+        let (mins, time_delta) = if mins > 60 {
+            (0, Some(TimeDelta::minutes(mins as i64)))
+        } else {
+            (mins, None)
+        };
+
+        println!("make_utc_datetime: {} - {:?}", mins, time_delta);
+
+        let naive_date = date
+            .and_hms_opt(hours, mins, secs)
+            .unwrap();
+
+        let naive_date = if let Some(time_delta) = time_delta {
+            naive_date.checked_add_signed(time_delta).unwrap()
+        } else {
+            naive_date
+        };
+
+        chrono::DateTime::from_naive_utc_and_offset(naive_date, chrono::Utc)
+    }
+
+}

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -183,13 +183,11 @@ mod tests {
         let day_ = 14;
         let genesis_0_date = NaiveDate::from_ymd_opt(2025, 5, day_).unwrap();
         let genesis_0: NaiveDateTime = genesis_0_date.and_hms_opt(4, 0, 0).unwrap();
-        let genesis: DateTime<Utc> =
-            chrono::DateTime::from_naive_utc_and_offset(genesis_0, chrono::Utc);
+        let genesis: DateTime<Utc> = DateTime::from_naive_utc_and_offset(genesis_0, Utc);
 
         let now_f = move || {
             let now_0: NaiveDateTime = genesis_0_date.and_hms_opt(4 + 2, 0, 0).unwrap();
-            let now: DateTime<Utc> =
-                chrono::DateTime::from_naive_utc_and_offset(now_0, chrono::Utc);
+            let now: DateTime<Utc> = DateTime::from_naive_utc_and_offset(now_0, Utc);
             now
         };
 
@@ -327,6 +325,8 @@ mod tests {
             assert!(matches!(res, Err(WaitUntilError::TooLow(_, _))));
         }
     }
+
+    // Helpers
 
     fn make_utc_datetime(date: NaiveDate, hours: u32, mins: u32, secs: u32) -> DateTime<Utc> {
         let (mins, time_delta) = if mins > 60 {

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -24,11 +24,11 @@ pub struct EpochService2 {
     /// Duration of an epoch (quotas reset every epoch)
     epoch_duration: Duration,
     /// Current epoch
-    pub current_epoch: Arc<RwLock<Epoch>>,
+    pub(crate) current_epoch: Arc<RwLock<Epoch>>,
     /// Genesis time (aka when the service has been started at the first time)
     genesis: DateTime<Utc>,
     /// Channel to notify when an epoch has just changed
-    pub epoch_changes: Arc<Notify>,
+    pub(crate) epoch_changes: Arc<Notify>, // assume single subscriber (see tokio Notify doc)
 }
 
 impl EpochService2 {
@@ -50,7 +50,7 @@ impl EpochService2 {
                 Ok((current_epoch, wait_until)) => break (current_epoch, wait_until),
                 Err(WaitUntilError::TooLow(d1, d2)) => {
                     // Wait until is too low (according to const WAIT_UNTIL_MIN_DURATION)
-                    // so we will retry (WAIT_UNTIL_MAX_COMPUTE_ERROR many times) after a short sleep
+                    // so we will retry (WAIT_UNTIL_MAX_RETRY many times) after a short sleep
                     debug!("compute_wait_until return TooLow, will retry after a sleep...");
                     tokio::time::sleep(WAIT_UNTIL_MIN_DURATION).await;
                     retry_counter += 1;
@@ -68,9 +68,6 @@ impl EpochService2 {
                 }
             }
         };
-        // Debug
-        // let current_epoch = 0;
-        // let mut wait_until = tokio::time::Instant::now();
 
         *self.current_epoch.write() = current_epoch.into();
         debug!("Initial epoch: {}", current_epoch);
@@ -107,6 +104,7 @@ impl EpochService2 {
                 gauge!(EPOCH_SERVICE_CURRENT_EPOCH.name, "prover" => "epoch service")
                     .set(current_epoch as f64);
 
+                //
                 self.epoch_changes.notify_one();
             }
         }
@@ -115,8 +113,8 @@ impl EpochService2 {
     fn compute_wait_until<T, F: Fn() -> DateTime<Utc>, TF: Fn() -> T>(
         genesis: &DateTime<Utc>,
         epoch_duration: &Duration,
-        now: &F,
-        now2: &TF,
+        wall_clock_now: &F,
+        monotonic_now: &TF,
     ) -> Result<(i64, T), WaitUntilError>
     where
         T: std::fmt::Debug + Add<Duration, Output = T>,
@@ -126,11 +124,11 @@ impl EpochService2 {
         //       but in unit test, we use now() == now2() as it is easier to manipulate DateTime<Utc>
 
         let (current_epoch, _current_epoch_start_ts, current_epoch_end_ts) =
-            Self::compute_current_epoch_0(genesis, now, epoch_duration);
+            Self::compute_current_epoch_0(genesis, wall_clock_now, epoch_duration);
 
         // time to wait to next epoch
-        let now_ = now();
-        let now_2_ = now2();
+        let now_ = wall_clock_now();
+        let now_2_ = monotonic_now();
         let wait_until_0_ = current_epoch_end_ts - now_.timestamp();
         let wait_until_0 = Duration::from_secs(wait_until_0_ as u64);
         if wait_until_0 < WAIT_UNTIL_MIN_DURATION {
@@ -216,7 +214,6 @@ impl TryFrom<EpochService2Config> for EpochService2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::providers::WatchTxError::Timeout;
     use chrono::{NaiveDate, NaiveDateTime, TimeDelta};
 
     #[test]

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -1,8 +1,4 @@
-use std::{
-    ops::Add,
-    sync::Arc,
-    time::Duration
-};
+use std::{ops::Add, sync::Arc, time::Duration};
 // third-party
 use chrono::{DateTime, NaiveDate, NaiveDateTime, OutOfRangeError, TimeDelta, Utc};
 use metrics::{gauge, histogram};
@@ -40,7 +36,6 @@ impl EpochService2 {
     //       + metrics already tracks the current epoch / epoch_slice
     // #[instrument(skip(self), fields(self.epoch_duration, self.genesis, self.current_epoch))]
     pub(crate) async fn listen_for_new_epoch(&self) -> Result<(), AppError2> {
-
         let mut retry_counter = 0;
         // Note: compute_wait_until return the duration to wait (from now until the next epoch)
         //       this can be very low (if we start the program near the end of an epoch)
@@ -94,8 +89,14 @@ impl EpochService2 {
                 wait_until = if let Some(wait_until) = wait_until.checked_add(self.epoch_duration) {
                     wait_until
                 } else {
-                    error!("wait_until overflows, previous value: {:?}, epoch_duration: {:?}", wait_until, self.epoch_duration);
-                    return Err(AppError2::EpochServiceOverflow(wait_until, self.epoch_duration));
+                    error!(
+                        "wait_until overflows, previous value: {:?}, epoch_duration: {:?}",
+                        wait_until, self.epoch_duration
+                    );
+                    return Err(AppError2::EpochServiceOverflow(
+                        wait_until,
+                        self.epoch_duration,
+                    ));
                 };
 
                 *self.current_epoch.write() = current_epoch.into();
@@ -149,7 +150,6 @@ impl EpochService2 {
         now: &F,
         epoch_duration: &Duration,
     ) -> (i64, i64, i64) {
-
         debug_assert!(now() >= *genesis);
         debug_assert!(i64::try_from(epoch_duration.as_secs()).is_ok());
 
@@ -162,14 +162,9 @@ impl EpochService2 {
         // Unwrap safe: epoch_duration > 0 (Duration type ~= u64)
         let current_epoch = diff.checked_div(epoch_dur).unwrap();
 
-        let epoch_start_ts = genesis_timestamp
-            + (current_epoch
-                .checked_mul(epoch_dur)
-                .unwrap()); // unwrap safe: should not overflow (as epoch_duration is small)
-        let epoch_end_ts = genesis_timestamp
-            + ((current_epoch + 1)
-                .checked_mul(epoch_dur)
-                .unwrap()); // unwrap safe: should not overflow (as epoch_duration is small)
+        let epoch_start_ts = genesis_timestamp + (current_epoch.checked_mul(epoch_dur).unwrap()); // unwrap safe: should not overflow (as epoch_duration is small)
+        let epoch_end_ts =
+            genesis_timestamp + ((current_epoch + 1).checked_mul(epoch_dur).unwrap()); // unwrap safe: should not overflow (as epoch_duration is small)
 
         (current_epoch, epoch_start_ts, epoch_end_ts)
     }

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -130,11 +130,13 @@ impl EpochService2 {
         let now_ = wall_clock_now();
         let now_2_ = monotonic_now();
         // let wait_until_0_ = current_epoch_end_ts - now_.timestamp();
-        let wait_until_0_ms = current_epoch_end_ts.saturating_mul(1000)
-            - now_.timestamp_millis();
+        let wait_until_0_ms = current_epoch_end_ts.saturating_mul(1000) - now_.timestamp_millis();
         // Note: wait_until_0_ms can be < 0: system clock skew, NTP correction, suspend/resume
         if wait_until_0_ms < 0 {
-            return Err(WaitUntilError::TooLow(Duration::ZERO, WAIT_UNTIL_MIN_DURATION));
+            return Err(WaitUntilError::TooLow(
+                Duration::ZERO,
+                WAIT_UNTIL_MIN_DURATION,
+            ));
         }
         let wait_until_0 = Duration::from_millis(wait_until_0_ms as u64);
         if wait_until_0 < WAIT_UNTIL_MIN_DURATION {
@@ -220,8 +222,8 @@ impl TryFrom<EpochService2Config> for EpochService2 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{NaiveDate, NaiveDateTime, TimeDelta};
     use crate::ARGS_DEFAULT_GENESIS;
+    use chrono::{NaiveDate, NaiveDateTime, TimeDelta};
     use serial_test::serial;
 
     #[test]
@@ -377,7 +379,6 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_service() {
-
         let epoch_duration = Duration::from_secs(30);
         let cfg = EpochService2Config {
             epoch_duration,
@@ -390,32 +391,31 @@ mod tests {
         let mut current_epoch = *epoch_service.current_epoch.read();
 
         // Start epoch service
-        let _ = tokio::task::spawn(async move {
-            epoch_service.listen_for_new_epoch().await
-        });
+        let _ = tokio::task::spawn(async move { epoch_service.listen_for_new_epoch().await });
 
         let counter_max = 3;
-        let res = tokio::task::spawn(
-            tokio::time::timeout(
-                epoch_duration.checked_mul(counter_max + 1).unwrap(),
-                async move {
-                        let mut counter = 0;
-                        loop {
-                            let res = notifier.notified().await;
-                            counter += 1;
-                            if counter >= counter_max {
-                                break;
-                            }
-
-                            let epoch = *epoch_store.read();
-                            if epoch != current_epoch + 1 && current_epoch != Epoch::from(0) {
-                                panic!("Start with epoch: {:?}, and now in epoch: {:?}, aborting unit test...", current_epoch, epoch);
-                            }
-                            current_epoch = epoch;
-                        }
+        let res = tokio::task::spawn(tokio::time::timeout(
+            epoch_duration.checked_mul(counter_max + 1).unwrap(),
+            async move {
+                let mut counter = 0;
+                loop {
+                    let res = notifier.notified().await;
+                    counter += 1;
+                    if counter >= counter_max {
+                        break;
                     }
-            )
-        );
+
+                    let epoch = *epoch_store.read();
+                    if epoch != current_epoch + 1 && current_epoch != Epoch::from(0) {
+                        panic!(
+                            "Start with epoch: {:?}, and now in epoch: {:?}, aborting unit test...",
+                            current_epoch, epoch
+                        );
+                    }
+                    current_epoch = epoch;
+                }
+            },
+        ));
 
         let _res = res.await.unwrap().unwrap();
     }

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use tokio::sync::Notify;
 use tracing::{debug, error};
 // Common?
-use crate::epoch_service::{Epoch, WaitUntilError};
+use crate::epoch_service::{Epoch, EpochServiceInitError, WaitUntilError, DEFAULT_EPOCH_DURATION};
 // Internal
 use crate::error::AppError2;
 use crate::metrics::{
@@ -33,14 +33,14 @@ pub struct EpochService2 {
 
 impl EpochService2 {
     // Note: listen_for_new_epoch never ends so no log will happen with #[instrument]
-    //       + metrics already tracks the current epoch / epoch_slice
+    //       + metrics already tracks the current epoch
     // #[instrument(skip(self), fields(self.epoch_duration, self.genesis, self.current_epoch))]
     pub(crate) async fn listen_for_new_epoch(&self) -> Result<(), AppError2> {
         let mut retry_counter = 0;
         // Note: compute_wait_until return the duration to wait (from now until the next epoch)
         //       this can be very low (if we start the program near the end of an epoch)
         //       so we retry a few times if necessary
-        let (current_epoch, mut wait_until) = loop {
+        let (mut current_epoch, mut wait_until) = loop {
             match EpochService2::compute_wait_until(
                 &self.genesis,
                 &self.epoch_duration,
@@ -99,6 +99,7 @@ impl EpochService2 {
                     ));
                 };
 
+                current_epoch += 1;
                 *self.current_epoch.write() = current_epoch.into();
 
                 // Note: based on this link https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
@@ -169,6 +170,53 @@ impl EpochService2 {
         (current_epoch, epoch_start_ts, epoch_end_ts)
     }
 }
+
+/// Configuration for EpochService2
+/// (epoch_duration, genesis)
+pub struct EpochService2Config {
+    /// Duration of an epoch (quotas reset every epoch). Default: 24 hours.
+    pub epoch_duration: Duration,
+    /// Genesis timestamp
+    pub genesis: DateTime<Utc>,
+}
+
+impl EpochService2Config {
+
+    /// Create config with custom epoch duration
+    pub fn new(
+        epoch_duration: Duration,
+        genesis: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            epoch_duration,
+            genesis,
+        }
+    }
+}
+
+impl TryFrom<EpochService2Config> for EpochService2 {
+    type Error = EpochServiceInitError;
+
+    fn try_from(config: EpochService2Config) -> Result<Self, Self::Error> {
+        if config.genesis >= Utc::now() {
+            return Err(EpochServiceInitError::FutureGenesis);
+        }
+
+        if config.epoch_duration.as_secs() == 0 {
+            return Err(EpochServiceInitError::EpochDuration);
+        }
+
+        // TODO: add more check?
+
+        Ok(Self {
+            epoch_duration: config.epoch_duration,
+            current_epoch: Arc::new(Default::default()),
+            genesis: config.genesis,
+            epoch_changes: Arc::new(Default::default()),
+        })
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -17,20 +17,21 @@ use crate::metrics::{
     EPOCH_SERVICE_CURRENT_EPOCH, EPOCH_SERVICE_CURRENT_EPOCH_SLICE, EPOCH_SERVICE_DRIFT_MILLIS,
 };
 
-/// Minimum duration returned by EpochService2::compute_wait_until()
+/// EpochService2::compute_wait_until() can return a low duration (see Notes in listen_for_new_epoch)
+/// So we need a minimum threshold to accept or not this duration
 const WAIT_UNTIL_MIN_DURATION: Duration = Duration::from_secs(10);
 /// EpochService::compute_wait_until() can return an error like TooLow (see WAIT_UNTIL_MIN_DURATION)
 /// so the epoch service will retry X many times.
-const WAIT_UNTIL_MAX_RETRY: usize = 10;
+const WAIT_UNTIL_MAX_RETRY: usize = 5;
 
 pub struct EpochService2 {
     /// Duration of an epoch (quotas reset every epoch)
     epoch_duration: Duration,
-    /// Current epoch and epoch slice
+    /// Current epoch
     pub current_epoch: Arc<RwLock<Epoch>>,
     /// Genesis time (aka when the service has been started at the first time)
     genesis: DateTime<Utc>,
-    /// Channel to notify when an epoch / epoch slice has just changed
+    /// Channel to notify when an epoch has just changed
     pub epoch_changes: Arc<Notify>,
 }
 
@@ -39,7 +40,11 @@ impl EpochService2 {
     //       + metrics already tracks the current epoch / epoch_slice
     // #[instrument(skip(self), fields(self.epoch_duration, self.genesis, self.current_epoch))]
     pub(crate) async fn listen_for_new_epoch(&self) -> Result<(), AppError2> {
+
         let mut retry_counter = 0;
+        // Note: compute_wait_until return the duration to wait (from now until the next epoch)
+        //       this can be very low (if we start the program near the end of an epoch)
+        //       so we retry a few times if necessary
         let (current_epoch, mut wait_until) = loop {
             match EpochService2::compute_wait_until(
                 &self.genesis,
@@ -85,10 +90,13 @@ impl EpochService2 {
                 histogram!(EPOCH_SERVICE_DRIFT_MILLIS.name, "prover" => "epoch service")
                     .record(now_ - wait_until);
 
-                // Note: could use checked_add() here, but it's quite impossible to have an overflow here
-                //       it would mean that the epoch_slice_duration is insanely large and wait_until
-                //       overflows as a timestamp
-                wait_until += self.epoch_duration;
+                // Note: checked_add() is used here but this is very unlikely an overflow can occur here
+                wait_until = if let Some(wait_until) = wait_until.checked_add(self.epoch_duration) {
+                    wait_until
+                } else {
+                    error!("wait_until overflows, previous value: {:?}, epoch_duration: {:?}", wait_until, self.epoch_duration);
+                    return Err(AppError2::EpochServiceOverflow(wait_until, self.epoch_duration));
+                };
 
                 *self.current_epoch.write() = current_epoch.into();
 
@@ -111,12 +119,17 @@ impl EpochService2 {
     where
         T: std::fmt::Debug + Add<Duration, Output = T>,
     {
-        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) =
+        // Note: we need to now() & now2() function as in production (see listen_for_new_epoch)
+        //       now() -> DateTime<Utc> && now2() returns tokio::time::Instant
+        //       but in unit test, we use now() == now2() as it is easier to manipulate DateTime<Utc>
+
+        let (current_epoch, _current_epoch_start_ts, current_epoch_end_ts) =
             Self::compute_current_epoch_0(genesis, now, epoch_duration);
 
-        // TODO / FIXME - Troubleshot: weird to use now() & now2() at different time here...
         // time to wait to next epoch
-        let wait_until_0_ = current_epoch_end_ts - now().timestamp();
+        let now_ = now();
+        let now_2_ = now2();
+        let wait_until_0_ = current_epoch_end_ts - now_.timestamp();
         let wait_until_0 = Duration::from_secs(wait_until_0_ as u64);
         if wait_until_0 < WAIT_UNTIL_MIN_DURATION {
             return Err(WaitUntilError::TooLow(
@@ -125,7 +138,7 @@ impl EpochService2 {
             ));
         }
 
-        let wait_until = now2() + wait_until_0;
+        let wait_until = now_2_ + wait_until_0;
         Ok((current_epoch, wait_until))
     }
 
@@ -136,51 +149,30 @@ impl EpochService2 {
         now: &F,
         epoch_duration: &Duration,
     ) -> (i64, i64, i64) {
-        debug_assert!(now() > *genesis);
-        debug_assert!(epoch_duration.as_secs() > 0);
+
+        debug_assert!(now() >= *genesis);
         debug_assert!(i64::try_from(epoch_duration.as_secs()).is_ok());
+
+        let epoch_dur = epoch_duration.as_secs() as i64;
 
         let genesis_timestamp = genesis.timestamp();
         let now_timestamp = now().timestamp();
         // Get time delta between genesis
         let diff = now_timestamp - genesis_timestamp;
-        let current_epoch = diff.checked_div(epoch_duration.as_secs() as i64).unwrap();
+        // Unwrap safe: epoch_duration > 0 (Duration type ~= u64)
+        let current_epoch = diff.checked_div(epoch_dur).unwrap();
 
-        let epoch_start = genesis_timestamp
+        let epoch_start_ts = genesis_timestamp
             + (current_epoch
-                .checked_mul(epoch_duration.as_secs() as i64)
-                .unwrap());
-        let epoch_end = genesis_timestamp
+                .checked_mul(epoch_dur)
+                .unwrap()); // unwrap safe: should not overflow (as epoch_duration is small)
+        let epoch_end_ts = genesis_timestamp
             + ((current_epoch + 1)
-                .checked_mul(epoch_duration.as_secs() as i64)
-                .unwrap());
+                .checked_mul(epoch_dur)
+                .unwrap()); // unwrap safe: should not overflow (as epoch_duration is small)
 
-        (current_epoch, epoch_start, epoch_end)
+        (current_epoch, epoch_start_ts, epoch_end_ts)
     }
-
-    /*
-    /// Compute current epoch since genesis
-    /// Return current_epoch AND DateTime of the start & end of this current epoch
-    fn compute_current_epoch<F: Fn() -> DateTime<Utc>>(
-        genesis: DateTime<Utc>,
-        now: &F,
-        epoch_duration: &Duration,
-    ) -> (i64, DateTime<Utc>, DateTime<Utc>) {
-
-        debug_assert!(now() > genesis);
-        debug_assert!(epoch_duration.as_secs() > 0);
-        debug_assert!(i64::try_from(epoch_duration.as_secs()).is_ok());
-
-
-        let diff = now() - genesis;
-        // Unwrap safe: epoch_duration > 0 + safe to convert to i64
-        let current_epoch = diff.checked_div(epoch_duration.as_secs() as i32).unwrap();
-        let epoch_start = genesis + (current_epoch.checked_mul(epoch_duration.as_secs() as i32).unwrap());
-        let epoch_end = genesis + (current_epoch.checked_mul(epoch_duration.as_secs() as i32 + 1).unwrap());
-
-        (0, epoch_start, epoch_end)
-    }
-    */
 }
 
 #[cfg(test)]
@@ -284,7 +276,7 @@ mod tests {
         let date_0 = NaiveDate::from_ymd_opt(2025, 5, 14).unwrap();
         let datetime_0 = date_0.and_hms_opt(0, 0, 0).unwrap();
 
-        let genesis: DateTime<Utc> = chrono::DateTime::from_naive_utc_and_offset(datetime_0, Utc);
+        let genesis: DateTime<Utc> = DateTime::from_naive_utc_and_offset(datetime_0, Utc);
 
         {
             // Check wait_until close to genesis
@@ -348,8 +340,6 @@ mod tests {
             (mins, None)
         };
 
-        println!("make_utc_datetime: {} - {:?}", mins, time_delta);
-
         let naive_date = date.and_hms_opt(hours, mins, secs).unwrap();
 
         let naive_date = if let Some(time_delta) = time_delta {
@@ -358,6 +348,6 @@ mod tests {
             naive_date
         };
 
-        chrono::DateTime::from_naive_utc_and_offset(naive_date, chrono::Utc)
+        DateTime::from_naive_utc_and_offset(naive_date, Utc)
     }
 }

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -391,7 +391,7 @@ mod tests {
         let mut current_epoch = *epoch_service.current_epoch.read();
 
         // Start epoch service
-        let _ = tokio::task::spawn(async move { epoch_service.listen_for_new_epoch().await });
+        tokio::task::spawn(async move { epoch_service.listen_for_new_epoch().await });
 
         let counter_max = 3;
         let res = tokio::task::spawn(tokio::time::timeout(
@@ -417,7 +417,7 @@ mod tests {
             },
         ));
 
-        let _res = res.await.unwrap().unwrap();
+        res.await.unwrap().unwrap();
     }
 
     // Helpers

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -129,8 +129,14 @@ impl EpochService2 {
         // time to wait to next epoch
         let now_ = wall_clock_now();
         let now_2_ = monotonic_now();
-        let wait_until_0_ = current_epoch_end_ts - now_.timestamp();
-        let wait_until_0 = Duration::from_secs(wait_until_0_ as u64);
+        // let wait_until_0_ = current_epoch_end_ts - now_.timestamp();
+        let wait_until_0_ms = current_epoch_end_ts.saturating_mul(1000)
+            - now_.timestamp_millis();
+        // Note: wait_until_0_ms can be < 0: system clock skew, NTP correction, suspend/resume
+        if wait_until_0_ms < 0 {
+            return Err(WaitUntilError::TooLow(Duration::ZERO, WAIT_UNTIL_MIN_DURATION));
+        }
+        let wait_until_0 = Duration::from_millis(wait_until_0_ms as u64);
         if wait_until_0 < WAIT_UNTIL_MIN_DURATION {
             return Err(WaitUntilError::TooLow(
                 wait_until_0,

--- a/rln-prover/prover/src/epoch_service_2.rs
+++ b/rln-prover/prover/src/epoch_service_2.rs
@@ -1,16 +1,18 @@
-use std::ops::Add;
-use std::sync::Arc;
-use std::time::Duration;
-use alloy::consensus::BlockHeader;
+use std::{
+    ops::Add,
+    sync::Arc,
+    time::Duration
+};
+// third-party
+use chrono::{DateTime, NaiveDate, NaiveDateTime, OutOfRangeError, TimeDelta, Utc};
+use metrics::{gauge, histogram};
 use parking_lot::RwLock;
 use tokio::sync::Notify;
 use tracing::{debug, error};
-use chrono::{DateTime, NaiveDate, NaiveDateTime, OutOfRangeError, TimeDelta, Utc};
-use metrics::{gauge, histogram};
-use crate::error::AppError2;
 // Common?
 use crate::epoch_service::{Epoch, WaitUntilError};
 // Internal
+use crate::error::AppError2;
 use crate::metrics::{
     EPOCH_SERVICE_CURRENT_EPOCH, EPOCH_SERVICE_CURRENT_EPOCH_SLICE, EPOCH_SERVICE_DRIFT_MILLIS,
 };
@@ -37,14 +39,13 @@ impl EpochService2 {
     //       + metrics already tracks the current epoch / epoch_slice
     // #[instrument(skip(self), fields(self.epoch_duration, self.genesis, self.current_epoch))]
     pub(crate) async fn listen_for_new_epoch(&self) -> Result<(), AppError2> {
-
         let mut retry_counter = 0;
         let (current_epoch, mut wait_until) = loop {
             match EpochService2::compute_wait_until(
                 &self.genesis,
                 &self.epoch_duration,
                 &|| Utc::now(),
-                &|| tokio::time::Instant::now()
+                &|| tokio::time::Instant::now(),
             ) {
                 Ok((current_epoch, wait_until)) => break (current_epoch, wait_until),
                 Err(WaitUntilError::TooLow(d1, d2)) => {
@@ -59,7 +60,7 @@ impl EpochService2 {
                         );
                         return Err(AppError2::EpochError(WaitUntilError::TooLow(d1, d2)));
                     }
-                },
+                }
                 Err(e) => {
                     // Another error (like OutOfRange) - exiting...
                     error!("Error computing the initial wait until: {}", e);
@@ -72,10 +73,7 @@ impl EpochService2 {
         // let mut wait_until = tokio::time::Instant::now();
 
         *self.current_epoch.write() = current_epoch.into();
-        debug!(
-            "Initial epoch: {}",
-            current_epoch
-        );
+        debug!("Initial epoch: {}", current_epoch);
 
         loop {
             debug!("wait until: {:?}", wait_until);
@@ -104,23 +102,27 @@ impl EpochService2 {
         }
     }
 
-    fn compute_wait_until<T: std::fmt::Debug, F: Fn() -> DateTime<Utc>, TF: Fn() -> T>(
+    fn compute_wait_until<T, F: Fn() -> DateTime<Utc>, TF: Fn() -> T>(
         genesis: &DateTime<Utc>,
         epoch_duration: &Duration,
         now: &F,
         now2: &TF,
     ) -> Result<(i64, T), WaitUntilError>
     where
-        T: Add<Duration, Output = T>,
+        T: std::fmt::Debug + Add<Duration, Output = T>,
     {
-        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = Self::compute_current_epoch_0(genesis, now, epoch_duration);
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) =
+            Self::compute_current_epoch_0(genesis, now, epoch_duration);
 
         // TODO / FIXME - Troubleshot: weird to use now() & now2() at different time here...
         // time to wait to next epoch
         let wait_until_0_ = current_epoch_end_ts - now().timestamp();
         let wait_until_0 = Duration::from_secs(wait_until_0_ as u64);
         if wait_until_0 < WAIT_UNTIL_MIN_DURATION {
-            return Err(WaitUntilError::TooLow(wait_until_0, WAIT_UNTIL_MIN_DURATION));
+            return Err(WaitUntilError::TooLow(
+                wait_until_0,
+                WAIT_UNTIL_MIN_DURATION,
+            ));
         }
 
         let wait_until = now2() + wait_until_0;
@@ -134,7 +136,6 @@ impl EpochService2 {
         now: &F,
         epoch_duration: &Duration,
     ) -> (i64, i64, i64) {
-
         debug_assert!(now() > *genesis);
         debug_assert!(epoch_duration.as_secs() > 0);
         debug_assert!(i64::try_from(epoch_duration.as_secs()).is_ok());
@@ -145,11 +146,16 @@ impl EpochService2 {
         let diff = now_timestamp - genesis_timestamp;
         let current_epoch = diff.checked_div(epoch_duration.as_secs() as i64).unwrap();
 
-        let epoch_start = genesis_timestamp + (current_epoch.checked_mul(epoch_duration.as_secs() as i64).unwrap());
-        let epoch_end = genesis_timestamp + ((current_epoch + 1).checked_mul(epoch_duration.as_secs() as i64).unwrap());
+        let epoch_start = genesis_timestamp
+            + (current_epoch
+                .checked_mul(epoch_duration.as_secs() as i64)
+                .unwrap());
+        let epoch_end = genesis_timestamp
+            + ((current_epoch + 1)
+                .checked_mul(epoch_duration.as_secs() as i64)
+                .unwrap());
 
         (current_epoch, epoch_start, epoch_end)
-
     }
 
     /*
@@ -179,54 +185,69 @@ impl EpochService2 {
 
 #[cfg(test)]
 mod tests {
-    use alloy::providers::WatchTxError::Timeout;
     use super::*;
+    use alloy::providers::WatchTxError::Timeout;
     use chrono::{NaiveDate, NaiveDateTime, TimeDelta};
 
     #[test]
     fn test_compute_current_epoch() {
-
         let epoch_duration = Duration::from_hours(1);
 
         let day_ = 14;
         let genesis_0_date = NaiveDate::from_ymd_opt(2025, 5, day_).unwrap();
-        let genesis_0: NaiveDateTime = genesis_0_date
-            .and_hms_opt(4, 0, 0)
-            .unwrap();
+        let genesis_0: NaiveDateTime = genesis_0_date.and_hms_opt(4, 0, 0).unwrap();
         let genesis: DateTime<Utc> =
             chrono::DateTime::from_naive_utc_and_offset(genesis_0, chrono::Utc);
 
         let now_f = move || {
-            let now_0: NaiveDateTime = genesis_0_date
-                .and_hms_opt(4+2, 0, 0)
-                .unwrap();
+            let now_0: NaiveDateTime = genesis_0_date.and_hms_opt(4 + 2, 0, 0).unwrap();
             let now: DateTime<Utc> =
                 chrono::DateTime::from_naive_utc_and_offset(now_0, chrono::Utc);
             now
         };
 
         // With epoch duration = 1 hour
-        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(1));
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) =
+            EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(1));
         assert_eq!(current_epoch, 2);
-        assert_eq!(current_epoch_start_ts, make_utc_datetime(genesis_0_date, 4+2, 0, 0).timestamp());
-        assert_eq!(current_epoch_end_ts, make_utc_datetime(genesis_0_date, 4+3, 0, 0).timestamp());
+        assert_eq!(
+            current_epoch_start_ts,
+            make_utc_datetime(genesis_0_date, 4 + 2, 0, 0).timestamp()
+        );
+        assert_eq!(
+            current_epoch_end_ts,
+            make_utc_datetime(genesis_0_date, 4 + 3, 0, 0).timestamp()
+        );
 
         // Same but with epoch duration = 2 hours
-        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(2));
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) =
+            EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(2));
         assert_eq!(current_epoch, 1);
-        assert_eq!(current_epoch_start_ts, make_utc_datetime(genesis_0_date, 4+2, 0, 0).timestamp());
-        assert_eq!(current_epoch_end_ts, make_utc_datetime(genesis_0_date, 4+4, 0, 0).timestamp());
+        assert_eq!(
+            current_epoch_start_ts,
+            make_utc_datetime(genesis_0_date, 4 + 2, 0, 0).timestamp()
+        );
+        assert_eq!(
+            current_epoch_end_ts,
+            make_utc_datetime(genesis_0_date, 4 + 4, 0, 0).timestamp()
+        );
 
         // Same but with epoch duration = 15 minutes
-        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_mins(15));
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) =
+            EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_mins(15));
         assert_eq!(current_epoch, 8);
-        assert_eq!(current_epoch_start_ts, make_utc_datetime(genesis_0_date, 6, 0, 0).timestamp());
-        assert_eq!(current_epoch_end_ts, make_utc_datetime(genesis_0_date, 6, 15, 0).timestamp());
+        assert_eq!(
+            current_epoch_start_ts,
+            make_utc_datetime(genesis_0_date, 6, 0, 0).timestamp()
+        );
+        assert_eq!(
+            current_epoch_end_ts,
+            make_utc_datetime(genesis_0_date, 6, 15, 0).timestamp()
+        );
     }
 
     #[test]
     fn test_compute_current_epoch_2() {
-
         // Test compute_current_epoch when now() is close to genesis time (expect current_epoch == 0)
 
         let epoch_duration = Duration::from_hours(1);
@@ -239,14 +260,21 @@ mod tests {
         let genesis: DateTime<Utc> =
             chrono::DateTime::from_naive_utc_and_offset(genesis_0, chrono::Utc);
 
-        let now_f = move || { genesis.checked_add_signed(TimeDelta::new(1, 0).unwrap()).unwrap()  };
+        let now_f = move || {
+            genesis
+                .checked_add_signed(TimeDelta::new(1, 0).unwrap())
+                .unwrap()
+        };
 
-        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) = EpochService2::compute_current_epoch_0(
-            &genesis, &now_f, &Duration::from_hours(1));
+        let (current_epoch, current_epoch_start_ts, current_epoch_end_ts) =
+            EpochService2::compute_current_epoch_0(&genesis, &now_f, &Duration::from_hours(1));
 
         assert_eq!(current_epoch, 0);
         assert_eq!(current_epoch_start_ts, genesis.timestamp());
-        assert_eq!(current_epoch_end_ts, genesis.timestamp() + epoch_duration.as_secs() as i64);
+        assert_eq!(
+            current_epoch_end_ts,
+            genesis.timestamp() + epoch_duration.as_secs() as i64
+        );
     }
 
     #[test]
@@ -256,8 +284,7 @@ mod tests {
         let date_0 = NaiveDate::from_ymd_opt(2025, 5, 14).unwrap();
         let datetime_0 = date_0.and_hms_opt(0, 0, 0).unwrap();
 
-        let genesis: DateTime<Utc> =
-            chrono::DateTime::from_naive_utc_and_offset(datetime_0, Utc);
+        let genesis: DateTime<Utc> = chrono::DateTime::from_naive_utc_and_offset(datetime_0, Utc);
 
         {
             // Check wait_until close to genesis
@@ -268,9 +295,13 @@ mod tests {
                 genesis.checked_add_signed(t_delta).unwrap()
             };
 
-            let (current_epoch, wait_until) = EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now).unwrap();
+            let (current_epoch, wait_until) =
+                EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now).unwrap();
             assert_eq!(current_epoch, 0);
-            assert_eq!(wait_until, make_utc_datetime(date_0, 0, epoch_duration_ as u32, 0));
+            assert_eq!(
+                wait_until,
+                make_utc_datetime(date_0, 0, epoch_duration_ as u32, 0)
+            );
         }
 
         {
@@ -284,18 +315,20 @@ mod tests {
                 genesis.checked_add_signed(t_delta).unwrap()
             };
 
-            let (current_epoch, wait_until) = EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now).unwrap();
+            let (current_epoch, wait_until) =
+                EpochService2::compute_wait_until(&genesis, &epoch_duration, &now, &now).unwrap();
             assert_eq!(current_epoch, 1);
-            assert_eq!(wait_until, make_utc_datetime(date_0, 0, (epoch_duration_ * 2) as u32, 0));
+            assert_eq!(
+                wait_until,
+                make_utc_datetime(date_0, 0, (epoch_duration_ * 2) as u32, 0)
+            );
         }
-
 
         {
             // Check for WaitUntilError::TooLow
 
             let epoch_duration = Duration::from_mins(15);
             let now = || {
-
                 let epoch_duration_minus_1 =
                     epoch_duration - WAIT_UNTIL_MIN_DURATION + Duration::from_secs(1);
 
@@ -309,7 +342,6 @@ mod tests {
     }
 
     fn make_utc_datetime(date: NaiveDate, hours: u32, mins: u32, secs: u32) -> DateTime<Utc> {
-
         let (mins, time_delta) = if mins > 60 {
             (0, Some(TimeDelta::minutes(mins as i64)))
         } else {
@@ -318,9 +350,7 @@ mod tests {
 
         println!("make_utc_datetime: {} - {:?}", mins, time_delta);
 
-        let naive_date = date
-            .and_hms_opt(hours, mins, secs)
-            .unwrap();
+        let naive_date = date.and_hms_opt(hours, mins, secs).unwrap();
 
         let naive_date = if let Some(time_delta) = time_delta {
             naive_date.checked_add_signed(time_delta).unwrap()
@@ -330,5 +360,4 @@ mod tests {
 
         chrono::DateTime::from_naive_utc_and_offset(naive_date, chrono::Utc)
     }
-
 }

--- a/rln-prover/prover/src/error.rs
+++ b/rln-prover/prover/src/error.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
 use alloy::signers::local::LocalSignerError;
 use alloy::transports::{RpcError, TransportErrorKind};
 use ark_serialize::SerializationError;
 use rln::error::ProofError;
 use smart_contract::{KarmaScError, KarmaTiersError, RlnScError};
+use std::time::Duration;
 // internal
 use crate::epoch_service::WaitUntilError;
 use crate::tier::ValidateTierLimitsError;
@@ -67,7 +67,9 @@ pub enum AppError2 {
     RpcTransportError(#[from] RpcError<TransportErrorKind>),
     #[error("Epoch service error: {0}")]
     EpochError(#[from] WaitUntilError),
-    #[error("Epoch service cannot wait til the next epoch, previous epoch time: {0:?} - epoch duration: {1:?}")]
+    #[error(
+        "Epoch service cannot wait til the next epoch, previous epoch time: {0:?} - epoch duration: {1:?}"
+    )]
     EpochServiceOverflow(tokio::time::Instant, Duration),
     #[error(transparent)]
     RegistryError(#[from] HandleTransferError2),

--- a/rln-prover/prover/src/error.rs
+++ b/rln-prover/prover/src/error.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use alloy::signers::local::LocalSignerError;
 use alloy::transports::{RpcError, TransportErrorKind};
 use ark_serialize::SerializationError;
@@ -66,6 +67,8 @@ pub enum AppError2 {
     RpcTransportError(#[from] RpcError<TransportErrorKind>),
     #[error("Epoch service error: {0}")]
     EpochError(#[from] WaitUntilError),
+    #[error("Epoch service cannot wait til the next epoch, previous epoch time: {0:?} - epoch duration: {1:?}")]
+    EpochServiceOverflow(tokio::time::Instant, Duration),
     #[error(transparent)]
     RegistryError(#[from] HandleTransferError2),
     #[error(transparent)]

--- a/rln-prover/prover/src/grpc_service.rs
+++ b/rln-prover/prover/src/grpc_service.rs
@@ -889,37 +889,11 @@ impl<P: Provider + Clone + Send + Sync + 'static> GrpcProverService<P> {
     }
 }
 
-/*
-/// UserTierInfo to UserTierInfoResult (Grpc message) conversion
-impl From<UserTierInfo> for UserTierInfoResult {
-    fn from(tier_info: UserTierInfo) -> Self {
-        let mut res = UserTierInfoResult {
-            current_epoch: tier_info.current_epoch.into(),
-            current_epoch_slice: tier_info.current_epoch_slice.into(),
-            tx_count: tier_info.epoch_tx_count,
-            tier: None,
-        };
-
-        if let Some(tier_name) = tier_info.tier_name
-            && let Some(tier_limit) = tier_info.tier_limit
-        {
-            res.tier = Some(Tier {
-                name: tier_name.into(),
-                quota: tier_limit.into(),
-            })
-        }
-
-        res
-    }
-}
-*/
-
 /// UserTierInfo2 to UserTierInfoResult (Grpc message) conversion
 impl From<UserTierInfo2> for UserTierInfoResult {
     fn from(tier_info: UserTierInfo2) -> Self {
         let mut res = UserTierInfoResult {
             current_epoch: tier_info.current_epoch.into(),
-            // current_epoch_slice: tier_info.current_epoch_slice.into(),
             current_epoch_slice: 0,
             tx_count: tier_info.epoch_tx_count,
             tier: None,

--- a/rln-prover/prover/src/karma_sc_listener.rs
+++ b/rln-prover/prover/src/karma_sc_listener.rs
@@ -366,8 +366,7 @@ mod tests {
     #[function_name::named]
     async fn test_handle_transfer_event() {
         let epoch = Epoch::from(11);
-        let epoch_slice = EpochSlice::from(42);
-        let epoch_store = Arc::new(RwLock::new((epoch, epoch_slice)));
+        let epoch_store = Arc::new(RwLock::new(epoch));
         let config = UserDb2Config {
             tree_count: 1,
             max_tree_count: 1,

--- a/rln-prover/prover/src/lib.rs
+++ b/rln-prover/prover/src/lib.rs
@@ -1,5 +1,6 @@
 mod args;
 mod epoch_service;
+mod epoch_service_2;
 mod error;
 mod grpc_service;
 mod karma_sc_listener;

--- a/rln-prover/prover/src/lib.rs
+++ b/rln-prover/prover/src/lib.rs
@@ -76,7 +76,6 @@ use rln_proof::RlnIdentifier;
 use smart_contract::{KarmaTiers::KarmaTiersInstance, KarmaTiersError, RLN, TIER_LIMITS};
 
 pub async fn run_prover(app_args: AppArgs) -> Result<(), AppError2> {
-
     /*
     // Epoch service with configurable epoch and slice duration
     // Production: epoch_duration = 24h (86400s), epoch_slice = 2min (120s)
@@ -99,20 +98,15 @@ pub async fn run_prover(app_args: AppArgs) -> Result<(), AppError2> {
         EpochService::try_from(epoch_config).expect("Failed to create epoch service");
     */
 
-
     let epoch_duration = Duration::from_secs(app_args.epoch_duration_secs);
     info!(
         "Starting epoch service: epoch_duration={}s",
         app_args.epoch_duration_secs
     );
-    let epoch_config = EpochService2Config::new(
-        epoch_duration,
-        ARGS_DEFAULT_GENESIS,
-    );
+    let epoch_config = EpochService2Config::new(epoch_duration, ARGS_DEFAULT_GENESIS);
 
     let epoch_service =
         EpochService2::try_from(epoch_config).expect("Failed to create epoch service");
-
 
     // Alloy provider (Smart contract provider)
     let provider = if app_args.ws_rpc_url.is_some() {

--- a/rln-prover/prover/src/lib.rs
+++ b/rln-prover/prover/src/lib.rs
@@ -76,27 +76,6 @@ use rln_proof::RlnIdentifier;
 use smart_contract::{KarmaTiers::KarmaTiersInstance, KarmaTiersError, RLN, TIER_LIMITS};
 
 pub async fn run_prover(app_args: AppArgs) -> Result<(), AppError2> {
-    /*
-    // Epoch service with configurable epoch and slice duration
-    // Production: epoch_duration = 24h (86400s), epoch_slice = 2min (120s)
-    // Testing: epoch_duration = 60s, epoch_slice = 10s (enables quota reset testing)
-    use crate::epoch_service::EpochServiceConfig;
-
-    let epoch_duration = Duration::from_secs(app_args.epoch_duration_secs);
-
-    info!(
-        "Starting epoch service: epoch_duration={}s",
-        app_args.epoch_duration_secs
-    );
-
-    let epoch_config = EpochServiceConfig::with_epoch_duration(
-        epoch_duration,
-        Duration::from_secs(10), // default value - unused
-        ARGS_DEFAULT_GENESIS,
-    );
-    let epoch_service =
-        EpochService::try_from(epoch_config).expect("Failed to create epoch service");
-    */
 
     let epoch_duration = Duration::from_secs(app_args.epoch_duration_secs);
     info!(

--- a/rln-prover/prover/src/lib.rs
+++ b/rln-prover/prover/src/lib.rs
@@ -54,7 +54,7 @@ use tracing::{debug, info, warn};
 use zeroize::Zeroizing;
 // internal
 pub use crate::args::{ARGS_DEFAULT_GENESIS, AppArgs, AppArgsConfig};
-use crate::epoch_service::EpochService;
+use crate::epoch_service_2::{EpochService2, EpochService2Config};
 use crate::error::AppError2;
 use crate::grpc_service::GrpcProverService;
 use crate::karma_sc_listener::KarmaScEventListener;
@@ -76,6 +76,8 @@ use rln_proof::RlnIdentifier;
 use smart_contract::{KarmaTiers::KarmaTiersInstance, KarmaTiersError, RLN, TIER_LIMITS};
 
 pub async fn run_prover(app_args: AppArgs) -> Result<(), AppError2> {
+
+    /*
     // Epoch service with configurable epoch and slice duration
     // Production: epoch_duration = 24h (86400s), epoch_slice = 2min (120s)
     // Testing: epoch_duration = 60s, epoch_slice = 10s (enables quota reset testing)
@@ -95,6 +97,22 @@ pub async fn run_prover(app_args: AppArgs) -> Result<(), AppError2> {
     );
     let epoch_service =
         EpochService::try_from(epoch_config).expect("Failed to create epoch service");
+    */
+
+
+    let epoch_duration = Duration::from_secs(app_args.epoch_duration_secs);
+    info!(
+        "Starting epoch service: epoch_duration={}s",
+        app_args.epoch_duration_secs
+    );
+    let epoch_config = EpochService2Config::new(
+        epoch_duration,
+        ARGS_DEFAULT_GENESIS,
+    );
+
+    let epoch_service =
+        EpochService2::try_from(epoch_config).expect("Failed to create epoch service");
+
 
     // Alloy provider (Smart contract provider)
     let provider = if app_args.ws_rpc_url.is_some() {

--- a/rln-prover/prover/src/lib.rs
+++ b/rln-prover/prover/src/lib.rs
@@ -76,7 +76,6 @@ use rln_proof::RlnIdentifier;
 use smart_contract::{KarmaTiers::KarmaTiersInstance, KarmaTiersError, RLN, TIER_LIMITS};
 
 pub async fn run_prover(app_args: AppArgs) -> Result<(), AppError2> {
-
     let epoch_duration = Duration::from_secs(app_args.epoch_duration_secs);
     info!(
         "Starting epoch service: epoch_duration={}s",

--- a/rln-prover/prover/src/proof_service.rs
+++ b/rln-prover/prover/src/proof_service.rs
@@ -32,7 +32,7 @@ pub struct ProofService {
     receiver: Receiver<ProofGenerationData>,
     broadcast_sender:
         tokio::sync::broadcast::Sender<Result<ProofSendingData, ProofGenerationStringError>>,
-    current_epoch: Arc<RwLock<(Epoch, EpochSlice)>>,
+    current_epoch: Arc<RwLock<Epoch>>,
     user_db: UserDb2,
     rate_limit: RateLimit,
     id: u64,
@@ -44,7 +44,7 @@ impl ProofService {
         broadcast_sender: tokio::sync::broadcast::Sender<
             Result<ProofSendingData, ProofGenerationStringError>,
         >,
-        current_epoch: Arc<RwLock<(Epoch, EpochSlice)>>,
+        current_epoch: Arc<RwLock<Epoch>>,
         user_db: UserDb2,
         rate_limit: RateLimit,
         id: u64,
@@ -92,7 +92,7 @@ impl ProofService {
                 self.id, proof_generation_data.tx_sender
             );
 
-            let (current_epoch, _current_epoch_slice) = *self.current_epoch.read();
+            let current_epoch = *self.current_epoch.read();
             let user_db = self.user_db.clone();
             let proof_generation_data_ = proof_generation_data.clone();
             let rate_limit = self.rate_limit;
@@ -397,8 +397,7 @@ mod tests {
 
         // Epoch
         let epoch = Epoch::from(11);
-        let epoch_slice = EpochSlice::from(42);
-        let epoch_store = Arc::new(RwLock::new((epoch, epoch_slice)));
+        let epoch_store = Arc::new(RwLock::new(epoch));
 
         // User db
         let config = UserDb2Config {

--- a/rln-prover/prover/src/proof_service_tests.rs
+++ b/rln-prover/prover/src/proof_service_tests.rs
@@ -135,8 +135,7 @@ mod tests {
 
         // Epoch
         let epoch = Epoch::from(11);
-        let epoch_slice = EpochSlice::from(42);
-        let epoch_store = Arc::new(RwLock::new((epoch, epoch_slice)));
+        let epoch_store = Arc::new(RwLock::new(epoch));
 
         // User db
         let config = UserDb2Config {
@@ -313,8 +312,7 @@ mod tests {
 
         // Epoch
         let epoch = Epoch::from(11);
-        let epoch_slice = EpochSlice::from(42);
-        let epoch_store = Arc::new(RwLock::new((epoch, epoch_slice)));
+        let epoch_store = Arc::new(RwLock::new(epoch));
 
         // Limits
         let rate_limit = RateLimit::from(1);
@@ -398,8 +396,7 @@ mod tests {
 
         // Epoch
         let epoch = Epoch::from(11);
-        let epoch_slice = EpochSlice::from(42);
-        let epoch_store = Arc::new(RwLock::new((epoch, epoch_slice)));
+        let epoch_store = Arc::new(RwLock::new(epoch));
 
         // Limits
         let rate_limit = RateLimit::from(1);

--- a/rln-prover/prover/src/user_db_2.rs
+++ b/rln-prover/prover/src/user_db_2.rs
@@ -36,7 +36,6 @@ const TIER_LIMITS_NEXT_KEY: &str = "NEXT";
 #[derive(Debug, PartialEq)]
 pub struct UserTierInfo2 {
     pub(crate) current_epoch: Epoch,
-    pub(crate) current_epoch_slice: EpochSlice,
     pub(crate) epoch_tx_count: u64,
     pub(crate) karma_amount: U256,
     pub(crate) tier_name: Option<TierName>,
@@ -55,7 +54,7 @@ pub(crate) struct UserDb2 {
     db: Pool<Postgres>,
     config: UserDb2Config,
     rate_limit: RateLimit,
-    pub(crate) epoch_store: Arc<RwLock<(Epoch, EpochSlice)>>,
+    pub(crate) epoch_store: Arc<RwLock<Epoch>>,
 }
 
 impl std::fmt::Debug for UserDb2 {
@@ -73,7 +72,7 @@ impl UserDb2 {
     pub async fn new(
         db: Pool<Postgres>,
         config: UserDb2Config,
-        epoch_store: Arc<RwLock<(Epoch, EpochSlice)>>,
+        epoch_store: Arc<RwLock<Epoch>>,
         tier_limits: TierLimits,
         rate_limit: RateLimit,
     ) -> Result<Self, SqlxError> {
@@ -206,7 +205,7 @@ impl UserDb2 {
         incr_value: Option<i64>,
     ) -> Result<(EpochCounter, QuotaBonus), SqlxError> {
         let incr_value = incr_value.unwrap_or(1);
-        let (epoch, _epoch_slice) = *self.epoch_store.read();
+        let epoch = *self.epoch_store.read();
         tracing::info!(
             address = %address,
             incr_value = incr_value,
@@ -273,7 +272,7 @@ impl UserDb2 {
         address: &Address,
         bonus: QuotaBonus,
     ) -> Result<(), SqlxError> {
-        let (epoch, _) = *self.epoch_store.read();
+        let epoch = *self.epoch_store.read();
         sqlx::query(
             "UPDATE tx_counter SET epoch = $1, quota_bonus = quota_bonus + $2 WHERE address = $3",
         )
@@ -302,7 +301,7 @@ impl UserDb2 {
     }
 
     fn counters_from_key(&self, model: TxCounterSqlx) -> (EpochCounter, QuotaBonus) {
-        let (epoch, _epoch_slice) = *self.epoch_store.read();
+        let epoch = *self.epoch_store.read();
         let cmp = model.epoch == i64::from(epoch);
 
         let address = Address::from_slice(model.address.as_slice());
@@ -544,12 +543,10 @@ impl UserDb2 {
         let tier_match = tier_limits.get_tier_by_karma(&karma_amount);
 
         let user_tier_info = {
-            let (current_epoch, current_epoch_slice) = *self.epoch_store.read();
+            let current_epoch = *self.epoch_store.read();
             let mut t = UserTierInfo2 {
                 current_epoch,
-                current_epoch_slice,
                 epoch_tx_count: epoch_tx_count.into(),
-                // epoch_slice_tx_count: epoch_slice_tx_count.into(),
                 karma_amount,
                 tier_name: None,
                 tier_limit: None,
@@ -598,7 +595,7 @@ impl UserDb2 {
     ///
     /// Returns true if the address is denied in the current epoch, false otherwise
     pub async fn is_denied(&self, address: &Address) -> Result<bool, SqlxError> {
-        let (current_epoch, _) = *self.epoch_store.read();
+        let current_epoch = *self.epoch_store.read();
         let current_epoch_i64 = i64::from(current_epoch);
 
         let res: i64 =
@@ -623,7 +620,7 @@ impl UserDb2 {
         address: &Address,
         reason: Option<String>,
     ) -> Result<bool, SqlxError> {
-        let (current_epoch, _) = *self.epoch_store.read();
+        let current_epoch = *self.epoch_store.read();
         let current_epoch_i64 = i64::from(current_epoch);
         let now_ = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -678,7 +675,7 @@ impl UserDb2 {
         &self,
         address: &Address,
     ) -> Result<Option<DenyListSqlx>, SqlxError> {
-        let (current_epoch, _) = *self.epoch_store.read();
+        let current_epoch = *self.epoch_store.read();
         let current_epoch_i64 = i64::from(current_epoch);
 
         let result: Option<DenyListSqlx> =
@@ -1008,7 +1005,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(tier_info.epoch_tx_count, 1);
-        // assert_eq!(tier_info.epoch_slice_tx_count, 1);
     }
 
     #[tokio::test]

--- a/rln-prover/prover/src/user_db_2_tests.rs
+++ b/rln-prover/prover/src/user_db_2_tests.rs
@@ -29,8 +29,7 @@ mod tests {
 
         let epoch_store = Arc::new(RwLock::new(Default::default()));
         let epoch = 1;
-        let epoch_slice = 42;
-        *epoch_store.write() = (Epoch::from(epoch), EpochSlice::from(epoch_slice));
+        *epoch_store.write() = Epoch::from(epoch);
 
         let config = UserDb2Config {
             tree_count: 1,
@@ -399,7 +398,7 @@ mod tests {
         .await?;
 
         // Set epoch to 1
-        *epoch_store.write() = (Epoch::from(1i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(1i64);
 
         assert_eq!(user_db.is_denied(&ADDR_1).await?, false);
         assert_eq!(user_db.is_denied(&ADDR_2).await?, false);
@@ -409,11 +408,11 @@ mod tests {
 
         assert_eq!(user_db.is_denied(&ADDR_3).await?, true);
         // Check that in a future epoch, ADDR_3 is not denied anymore
-        *epoch_store.write() = (Epoch::from(2i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(2i64);
         assert_eq!(user_db.is_denied(&ADDR_3).await?, false);
 
         // Go back to epoch 1
-        *epoch_store.write() = (Epoch::from(1i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(1i64);
         assert_eq!(user_db.is_denied(&ADDR_1).await?, false);
         assert_eq!(user_db.is_denied(&ADDR_2).await?, false);
 
@@ -466,7 +465,7 @@ mod tests {
         .await?;
 
         // Set epoch to 1
-        *epoch_store.write() = (Epoch::from(1i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(1i64);
         user_db.register_user(ADDR_3).await.unwrap();
         // Check this is an INSERT
         assert_eq!(user_db.add_to_deny_list(&ADDR_3, None).await?, true);
@@ -509,33 +508,33 @@ mod tests {
         user_db.register_user(ADDR_1).await.unwrap();
 
         // Add ADDR_3 to deny list at epoch 1
-        *epoch_store.write() = (Epoch::from(1i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(1i64);
         user_db.add_to_deny_list(&ADDR_3, None).await?;
 
         // Add ADDR_1 to deny list at epoch 2
-        *epoch_store.write() = (Epoch::from(2i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(2i64);
         user_db.add_to_deny_list(&ADDR_1, None).await?;
 
         // clear_deny_list with epoch 1 will clean nothing (no entries with epoch < 1)
         user_db.clear_deny_list(1).await?;
         // Both entries still visible at epoch 1
-        *epoch_store.write() = (Epoch::from(1i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(1i64);
         assert!(user_db.get_deny_list_entry(&ADDR_3).await?.is_some());
         assert!(user_db.get_deny_list_entry(&ADDR_1).await?.is_some());
 
         // clear_deny_list with epoch 2 removes entries with epoch < 2 (i.e. ADDR_3 at epoch 1)
         user_db.clear_deny_list(2).await?;
-        *epoch_store.write() = (Epoch::from(1i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(1i64);
         assert!(user_db.get_deny_list_entry(&ADDR_3).await?.is_none());
         assert!(user_db.get_raw_deny_list_entry(&ADDR_3).await?.is_none());
         // ADDR_1 at epoch 2 is still present
-        *epoch_store.write() = (Epoch::from(2i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(2i64);
         assert!(user_db.get_deny_list_entry(&ADDR_1).await?.is_some());
         assert!(user_db.get_raw_deny_list_entry(&ADDR_1).await?.is_some());
 
         // clear_deny_list with epoch 3 removes entries with epoch < 3 (i.e. ADDR_1 at epoch 2)
         user_db.clear_deny_list(3).await?;
-        *epoch_store.write() = (Epoch::from(2i64), EpochSlice::from(0i64));
+        *epoch_store.write() = Epoch::from(2i64);
         assert!(user_db.get_deny_list_entry(&ADDR_1).await?.is_none());
         assert!(user_db.get_raw_deny_list_entry(&ADDR_1).await?.is_none());
 

--- a/rln-prover/prover/src/user_db_service.rs
+++ b/rln-prover/prover/src/user_db_service.rs
@@ -26,7 +26,7 @@ impl UserDbService {
         db_conn: Pool<Postgres>,
         config: UserDb2Config,
         epoch_changes_notifier: Arc<Notify>,
-        epoch_store: Arc<RwLock<(Epoch, EpochSlice)>>,
+        epoch_store: Arc<RwLock<Epoch>>,
         rate_limit: RateLimit,
         tier_limits: TierLimits,
     ) -> Result<Self, UserDb2OpenError> {
@@ -42,17 +42,15 @@ impl UserDbService {
     }
 
     pub async fn listen_for_epoch_changes(&self) -> Result<(), AppError2> {
-        let (mut current_epoch, _) = *self.user_db.epoch_store.read();
+        let mut current_epoch = *self.user_db.epoch_store.read();
 
         loop {
             self.epoch_changes.notified().await;
-            let (new_epoch, _) = *self.user_db.epoch_store.read();
+            let new_epoch = *self.user_db.epoch_store.read();
             debug!("new epoch: {:?}", new_epoch);
             self.update_on_epoch_changes(
                 &mut current_epoch,
                 new_epoch,
-                // &mut current_epoch_slice,
-                // new_epoch_slice,
             )
             .await;
         }
@@ -63,8 +61,6 @@ impl UserDbService {
         &self,
         current_epoch: &mut Epoch,
         new_epoch: Epoch,
-        // current_epoch_slice: &mut EpochSlice,
-        // new_epoch_slice: EpochSlice,
     ) {
         if new_epoch > *current_epoch {
             info!(
@@ -96,6 +92,5 @@ impl UserDbService {
         }
 
         *current_epoch = new_epoch;
-        // *current_epoch_slice = new_epoch_slice;
     }
 }

--- a/rln-prover/prover/src/user_db_service.rs
+++ b/rln-prover/prover/src/user_db_service.rs
@@ -48,20 +48,13 @@ impl UserDbService {
             self.epoch_changes.notified().await;
             let new_epoch = *self.user_db.epoch_store.read();
             debug!("new epoch: {:?}", new_epoch);
-            self.update_on_epoch_changes(
-                &mut current_epoch,
-                new_epoch,
-            )
-            .await;
+            self.update_on_epoch_changes(&mut current_epoch, new_epoch)
+                .await;
         }
     }
 
     /// Internal - used by listen_for_epoch_changes
-    async fn update_on_epoch_changes(
-        &self,
-        current_epoch: &mut Epoch,
-        new_epoch: Epoch,
-    ) {
+    async fn update_on_epoch_changes(&self, current_epoch: &mut Epoch, new_epoch: Epoch) {
         if new_epoch > *current_epoch {
             info!(
                 "Epoch changed from {:?} to {:?}, clearing deny list",


### PR DESCRIPTION
This is rewrite of the EpochService service to remove the need to specify a valid epoch slice to make it work properly. In the process, the code has been cleaned up and should be easier to read than the previous one.
Also unit tests have been improved.