### PR TITLE
fix: user-friendly RLN prover rejection messages

### DIFF
--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidator.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidator.java
@@ -286,7 +286,7 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
           killSwitchGasPrice,
           premiumThreshold);
       return Optional.of(
-          "Gas kill switch is active. Gasless transactions are temporarily disabled.");
+          "Gasless transactions are temporarily disabled. Please pay premium gas to proceed.");
     }
 
     // Only validate local transactions via gRPC
@@ -368,8 +368,7 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
             consecutiveGrpcFailures.get(),
             timeSinceLastFailure,
             transaction.getHash().toHexString());
-        return Optional.of(
-            "RLN prover service unavailable (circuit breaker open). Please try again later.");
+        return Optional.of(SERVICE_UNAVAILABLE_MESSAGE);
       }
     }
 
@@ -438,27 +437,32 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
         grpcFailureCount.incrementAndGet();
         consecutiveGrpcFailures.set(0); // Rejection is a successful response, reset breaker
         LOG.warn("RLN prover rejected transaction {}", transaction.getHash());
-        return Optional.of("RLN prover rejected transaction");
+        return Optional.of(userFriendlyRejection(Status.Code.UNKNOWN, null));
       }
 
     } catch (final StatusRuntimeException sre) {
       // gRPC status-based responses: distinguish intentional rejections from transient errors
       Status.Code code = sre.getStatus().getCode();
+      String description = sre.getStatus().getDescription();
+      boolean killSwitchActive =
+          code == Status.Code.UNAVAILABLE
+              && description != null
+              && description.toLowerCase().contains("kill switch");
       if (code == Status.Code.RESOURCE_EXHAUSTED
           || code == Status.Code.NOT_FOUND
           || code == Status.Code.INVALID_ARGUMENT
           || code == Status.Code.PERMISSION_DENIED
-          || code == Status.Code.ALREADY_EXISTS) {
+          || code == Status.Code.ALREADY_EXISTS
+          || killSwitchActive) {
         // Intentional rejection by the prover (quota exceeded, unregistered user, bad input,
-        // duplicate tx)
+        // duplicate tx, kill switch). Kill-switch UNAVAILABLE is not a transient failure.
         consecutiveGrpcFailures.set(0); // Not a failure, reset circuit breaker
         LOG.warn(
             "RLN prover rejected transaction {} ({}): {}",
             transaction.getHash(),
             code,
-            sre.getStatus().getDescription());
-        return Optional.of(
-            "RLN prover rejected transaction (" + code + "): " + sre.getStatus().getDescription());
+            description);
+        return Optional.of(userFriendlyRejection(code, description));
       }
       // Transient gRPC error (UNAVAILABLE, DEADLINE_EXCEEDED, etc.)
       grpcFailureCount.incrementAndGet();
@@ -475,7 +479,7 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
             "Circuit breaker OPENING after {} consecutive gRPC failures. Will auto-recover after {} ms.",
             failures,
             circuitBreakerRecoveryMs);
-        return Optional.of("RLN prover service unavailable. Please try again later.");
+        return Optional.of(SERVICE_UNAVAILABLE_MESSAGE);
       }
       // Below threshold: graceful fallback - accept the transaction
       return Optional.empty();
@@ -494,11 +498,34 @@ public class RlnProverForwarderValidator implements PluginTransactionPoolValidat
             "Circuit breaker OPENING after {} consecutive gRPC failures. Will auto-recover after {} ms.",
             failures,
             circuitBreakerRecoveryMs);
-        return Optional.of("RLN prover service unavailable. Please try again later.");
+        return Optional.of(SERVICE_UNAVAILABLE_MESSAGE);
       }
       // Below threshold: graceful fallback - accept the transaction
       return Optional.empty();
     }
+  }
+
+  private static final String SERVICE_UNAVAILABLE_MESSAGE =
+      "Gasless transaction service is temporarily unavailable. Please try again shortly, or pay premium gas to proceed.";
+
+  // Messages below correspond 1:1 to statuses emitted by the prover's send_transaction
+  // (rln-prover/prover/src/grpc_service.rs).
+  private static String userFriendlyRejection(final Status.Code code, final String description) {
+    return switch (code) {
+      case NOT_FOUND ->
+          "Gasless transactions require Karma. Receive or earn Karma to your address first, then try again.";
+      case RESOURCE_EXHAUSTED ->
+          "Free transaction limit reached for your current Karma tier. Earn more Karma to upgrade your tier, or pay premium gas to proceed.";
+      case ALREADY_EXISTS ->
+          "This transaction is already being processed. Please wait before resubmitting.";
+      case INVALID_ARGUMENT -> "Transaction rejected: invalid transaction data.";
+      case UNAVAILABLE ->
+          description != null && description.toLowerCase().contains("kill switch")
+              ? "Gasless transactions are temporarily disabled. Please pay premium gas to proceed."
+              : SERVICE_UNAVAILABLE_MESSAGE;
+      default ->
+          "Gasless transaction rejected. Please try again shortly, or pay premium gas to proceed.";
+    };
   }
 
   /**

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidatorAuditFixTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/RlnProverForwarderValidatorAuditFixTest.java
@@ -185,7 +185,7 @@ class RlnProverForwarderValidatorAuditFixTest {
 
       Optional<String> result = ksValidator.validateTransaction(gaslessTx, true, false);
       assertThat(result).isPresent();
-      assertThat(result.get()).contains("kill switch");
+      assertThat(result.get()).contains("Gasless transactions are temporarily disabled");
 
       // Premium tx should be allowed even with kill switch
       org.hyperledger.besu.ethereum.core.Transaction premiumTx =

--- a/e2e/src/rln-gasless/deny-list-and-premium-gas.spec.ts
+++ b/e2e/src/rln-gasless/deny-list-and-premium-gas.spec.ts
@@ -176,7 +176,7 @@ describe("RLN Deny List and Premium Gas", () => {
         },
         10000,
       );
-      expect(error).toMatch(/quota|deny|denied|timeout|exceeded|resource/i);
+      expect(error).toMatch(/quota|deny|denied|timeout|exceeded|resource|karma|limit/i);
 
       logger.info(`${DENY_001.id}: PASSED ✓`);
     },
@@ -212,7 +212,7 @@ describe("RLN Deny List and Premium Gas", () => {
       });
 
       // Must be rejected - either denied (if deny list synced) or resource_exhausted (quota check)
-      expect(errorMessage).toMatch(/deny|denied|reject|quota|timeout|resource.*exhausted/i);
+      expect(errorMessage).toMatch(/deny|denied|reject|quota|timeout|resource.*exhausted|karma|limit/i);
 
       logger.info(`${DENY_002.id}: PASSED ✓`);
     },
@@ -245,7 +245,7 @@ describe("RLN Deny List and Premium Gas", () => {
         { to: TEST_RECIPIENT, value: 0n, data: uniqueTxData("deny003-verify-denied") },
         10000,
       );
-      expect(denyError).toMatch(/quota|deny|denied|timeout|exceeded|resource/i);
+      expect(denyError).toMatch(/quota|deny|denied|timeout|exceeded|resource|karma|limit/i);
 
       // Pay premium gas (transaction succeeds even while denied)
       // Premium gas now removes from deny list AND resets epoch counter (quota refresh)
@@ -334,7 +334,7 @@ describe("RLN Deny List and Premium Gas", () => {
         { to: TEST_RECIPIENT, value: 0n, data: uniqueTxData("deny005-verify-denied") },
         10000,
       );
-      expect(denyError).toMatch(/quota|deny|denied|timeout|exceeded|resource/i);
+      expect(denyError).toMatch(/quota|deny|denied|timeout|exceeded|resource|karma|limit/i);
 
       // Pay premium gas (succeeds even while denied)
       // Premium gas now removes from deny list AND resets epoch counter (quota refresh)
@@ -441,7 +441,7 @@ describe("RLN Deny List and Premium Gas", () => {
           },
           10000,
         );
-        expect(error).toMatch(/quota|deny|denied|timeout|exceeded|resource/i);
+        expect(error).toMatch(/quota|deny|denied|timeout|exceeded|resource|karma|limit/i);
       }
 
       logger.info(`${DENY_007.id}: PASSED ✓`);
@@ -533,7 +533,7 @@ describe("RLN Deny List and Premium Gas", () => {
           },
           10000,
         );
-        expect(error).toMatch(/quota|deny|denied|timeout|exceeded|resource/i);
+        expect(error).toMatch(/quota|deny|denied|timeout|exceeded|resource|karma|limit/i);
       }
 
       logger.info(`${DENY_009.id}: PASSED ✓`);
@@ -595,7 +595,7 @@ describe("RLN Deny List and Premium Gas", () => {
       );
 
       //  Must fail for proof/timeout reason
-      expect(errorMessage).toMatch(/timeout|rejected|proof|invalid/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|invalid|karma|gasless/i);
 
       logger.info(`${PREM_002.id}: PASSED ✓`);
     },

--- a/e2e/src/rln-gasless/gasless-transactions.spec.ts
+++ b/e2e/src/rln-gasless/gasless-transactions.spec.ts
@@ -214,7 +214,7 @@ describe("RLN Gasless Transactions", () => {
         data: uniqueTxData("gas002-exceed"),
       });
 
-      expect(errorMessage).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted/i);
+      expect(errorMessage).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted|karma|limit/i);
       logger.info(`${GAS_002.id}: Transaction rejected as expected (quota exhausted)`, { error: errorMessage });
 
       logger.info(`${GAS_002.id}: PASSED ✓`);
@@ -260,7 +260,7 @@ describe("RLN Gasless Transactions", () => {
       );
 
       // Error should indicate quota exhaustion or denial
-      expect(errorMessage).toMatch(/quota|deny|denied|timeout|exceeded|resource/i);
+      expect(errorMessage).toMatch(/quota|deny|denied|timeout|exceeded|resource|karma|limit/i);
 
       logger.info(`${GAS_003.id}: PASSED ✓`);
     },
@@ -297,7 +297,7 @@ describe("RLN Gasless Transactions", () => {
       );
 
       //  Must fail for proof/registration reason
-      expect(errorMessage).toMatch(/timeout|rejected|not registered|invalid|proof/i);
+      expect(errorMessage).toMatch(/timeout|rejected|not registered|invalid|proof|karma|gasless/i);
       logger.info(`${GAS_004.id}: Transaction rejected as expected`, { error: errorMessage });
 
       logger.info(`${GAS_004.id}: PASSED ✓`);
@@ -377,7 +377,7 @@ describe("RLN Gasless Transactions", () => {
         },
         10000, // 10s timeout for failure expectation
       );
-      expect(preEpochError).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted/i);
+      expect(preEpochError).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted|karma|limit/i);
 
       // Wait for next epoch (short epochs make this practical)
       logger.info(`Waiting for next epoch (max ${epochDuration + 2}s)...`);
@@ -454,7 +454,7 @@ describe("RLN Gasless Transactions", () => {
           10000, // 10s timeout for failure expectation
         );
         // Quota exceeded manifests as resource_exhausted error from prover
-        expect(error).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted/i);
+        expect(error).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted|karma|limit/i);
       }
 
       logger.info(`${GAS_007.id}: PASSED ✓`);
@@ -496,7 +496,7 @@ describe("RLN Gasless Transactions", () => {
         value: 0n,
         data: uniqueTxData("gas008-entry-exceed"),
       });
-      expect(entryError).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted/i);
+      expect(entryError).toMatch(/quota|exceeded|deny|denied|timeout|resource.*exhausted|karma|limit/i);
 
       // Verify Newbie user can send more than Entry tier
       // Send 4 to prove they have higher quota than Entry (4 < newbie quota of 6)
@@ -539,7 +539,7 @@ describe("RLN Gasless Transactions", () => {
 
       const elapsed = Date.now() - startTime;
 
-      expect(errorMessage).toMatch(/timeout|proof|rejected/i);
+      expect(errorMessage).toMatch(/timeout|proof|rejected|karma|gasless/i);
       //  Should timeout within proof timeout + buffer
       expect(elapsed).toBeLessThan(RLN_CONFIG.test.proofTimeoutMs + 2000);
 

--- a/e2e/src/rln-gasless/integration-and-errors.spec.ts
+++ b/e2e/src/rln-gasless/integration-and-errors.spec.ts
@@ -201,7 +201,7 @@ describe("RLN Integration and Error Handling", () => {
         value: 0n,
         data: uniqueTxData("int001-exceed"),
       });
-      expect(errorMessage).toMatch(/deny|denied|reject|quota|timeout|resource.*exhausted/i);
+      expect(errorMessage).toMatch(/deny|denied|reject|quota|timeout|resource.*exhausted|karma|limit/i);
       logger.info("Step 4: Gasless blocked after quota exhaustion");
 
       // Step 5: Pay premium gas (removes from deny list AND resets quota)
@@ -480,7 +480,7 @@ describe("RLN Integration and Error Handling", () => {
       const duration = Date.now() - startTime;
 
       // STRONG ASSERTIONS
-      expect(errorMessage).toMatch(/timeout|rejected|proof/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|karma|gasless/i);
       expect(duration).toBeLessThan(RLN_CONFIG.test.proofTimeoutMs + 3000);
 
       logger.info(`${ERR_002.id}: PASSED ✓`, {

--- a/e2e/src/rln-gasless/karma-tier-system.spec.ts
+++ b/e2e/src/rln-gasless/karma-tier-system.spec.ts
@@ -316,7 +316,7 @@ describe("RLN Karma and Tier System", () => {
         },
         10000, // 10s timeout
       );
-      expect(entryError).toMatch(/quota|exceeded|exhausted|deny|denied|timeout|resource/i);
+      expect(entryError).toMatch(/quota|exceeded|exhausted|deny|denied|timeout|resource|karma|limit/i);
 
       logger.info(`${KARMA_006.id}: PASSED ✓`);
     },
@@ -352,7 +352,7 @@ describe("RLN Karma and Tier System", () => {
       );
 
       //  Must be rejected
-      expect(errorMessage).toMatch(/timeout|rejected|proof|invalid|not registered/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|invalid|not registered|karma|gasless/i);
 
       logger.info(`${KARMA_007.id}: PASSED ✓`);
     },

--- a/e2e/src/rln-gasless/rln-proof-verification.spec.ts
+++ b/e2e/src/rln-gasless/rln-proof-verification.spec.ts
@@ -186,7 +186,7 @@ describe("RLN Proof Verification", () => {
       );
 
       //  Must fail with clear indication of proof/registration issue
-      expect(errorMessage).toMatch(/timeout|rejected|invalid|proof|not registered/i);
+      expect(errorMessage).toMatch(/timeout|rejected|invalid|proof|not registered|karma|gasless/i);
 
       logger.info(`${RLN_002.id}: PASSED ✓`);
     },
@@ -219,7 +219,7 @@ describe("RLN Proof Verification", () => {
       );
 
       //  Must fail for proof reasons, not data format
-      expect(errorMessage).toMatch(/timeout|rejected|proof|invalid/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|invalid|karma|gasless/i);
 
       logger.info(`${RLN_003.id}: PASSED ✓`);
     },
@@ -285,7 +285,7 @@ describe("RLN Proof Verification", () => {
       const duration = Date.now() - startTime;
 
       // STRONG ASSERTIONS
-      expect(errorMessage).toMatch(/timeout|rejected|proof/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|karma|gasless/i);
       // Should fail within proof timeout + small buffer
       expect(duration).toBeLessThan(RLN_CONFIG.test.proofTimeoutMs + 2000);
 
@@ -423,7 +423,7 @@ describe("RLN Proof Verification", () => {
       );
 
       //  Even zero-value tx requires proof
-      expect(errorMessage).toMatch(/timeout|rejected|proof/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|karma|gasless/i);
 
       // Now verify registered user CAN send zero-value
       const registeredUser = getEntryUser();
@@ -461,7 +461,7 @@ describe("RLN Proof Verification", () => {
       );
 
       //  Self-transfer also requires proof
-      expect(errorMessage).toMatch(/timeout|rejected|proof/i);
+      expect(errorMessage).toMatch(/timeout|rejected|proof|karma|gasless/i);
 
       // Now verify registered user CAN do self-transfer
       const registeredUser = getEntryUser();


### PR DESCRIPTION
Replaces raw gRPC error strings surfaced to users with actionable messages (Karma tier limits, kill-switch, duplicate tx, etc.). Also treats kill-switch UNAVAILABLE as a rejection rather than a transient failure.