### PR TITLE
chore: bump besu to beta-v6.2 and shomei plugin to v1.0.3

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -20,7 +20,8 @@ on:
 env:
   PROVER_IMAGE: 0xnadeem/status-network-rln-prover
   BESU_IMAGE: 0xnadeem/status-network-besu
-  BESU_PACKAGE_TAG: beta-v6-20260410083640-74d51b7
+  BESU_PACKAGE_TAG: beta-v6.2-20260413130658-9cb6f11
+  SHOMEI_PLUGIN_VERSION: "1.0.3"
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -129,13 +130,15 @@ jobs:
       - name: Set up tracer environment (Go + Java + Gradle + Besu)
         uses: ./.github/actions/setup-tracer-environment
 
-      - name: Build sequencer plugin
+      - name: Build sequencer + tracer plugins
         env:
           LINEA_DEV_ALLOW_WARNINGS: "true"
         run: |
           ./gradlew \
             :besu-plugins:linea-sequencer:sequencer:jar \
             :besu-plugins:linea-sequencer:sequencer:assembleDist \
+            :tracer:plugins:jar \
+            :tracer:plugins:assembleDist \
             -x test -x checkSpdxHeader -x spotlessJavaCheck -x spotlessGroovyGradleCheck \
             --no-daemon --configure-on-demand
 
@@ -159,50 +162,67 @@ jobs:
           shopt -s nullglob
           mkdir -p docker-build/plugins docker-build/native
 
-          LIBS_DIR=besu-plugins/linea-sequencer/sequencer/build/libs
-          DIST_DIR=besu-plugins/linea-sequencer/sequencer/build/distributions
+          SEQ_LIBS=besu-plugins/linea-sequencer/sequencer/build/libs
+          SEQ_DIST=besu-plugins/linea-sequencer/sequencer/build/distributions
+          TRACER_LIBS=tracer/plugins/build/libs
+          TRACER_DIST=tracer/plugins/build/distributions
 
-          echo "=== Available JARs ==="
-          ls -la "$LIBS_DIR"
-          echo "=== Available distributions ==="
-          ls -la "$DIST_DIR"
+          echo "=== Sequencer JARs ==="; ls -la "$SEQ_LIBS"
+          echo "=== Sequencer distributions ==="; ls -la "$SEQ_DIST"
+          echo "=== Tracer JARs ==="; ls -la "$TRACER_LIBS"
+          echo "=== Tracer distributions ==="; ls -la "$TRACER_DIST"
 
-          # Copy sequencer JAR (there should be exactly one linea-sequencer-*.jar)
-          JARS=("$LIBS_DIR"/linea-sequencer-*.jar)
-          if [[ ${#JARS[@]} -eq 0 ]]; then
-            echo "ERROR: no linea-sequencer-*.jar found in $LIBS_DIR"; exit 1
+          # Copy sequencer JAR
+          SEQ_JARS=("$SEQ_LIBS"/linea-sequencer-*.jar)
+          if [[ ${#SEQ_JARS[@]} -eq 0 ]]; then
+            echo "ERROR: no linea-sequencer-*.jar found in $SEQ_LIBS"; exit 1
           fi
-          cp "${JARS[0]}" docker-build/plugins/
-          echo "Installed sequencer JAR: $(basename "${JARS[0]}")"
+          cp "${SEQ_JARS[0]}" docker-build/plugins/
+          echo "Installed sequencer JAR: $(basename "${SEQ_JARS[0]}")"
 
-          # Pick the distribution zip that actually contains the JAR + dependency JARs.
-          # The besu-plugin-distribution plugin produces two zips; only one is populated.
-          DIST_ZIP=""
-          for z in "$DIST_DIR"/*.zip; do
-            if unzip -l "$z" 2>/dev/null | grep -qE "\.jar( |$)"; then
-              DIST_ZIP="$z"
-              break
-            fi
+          # Copy tracer plugin JAR — must come from the same source tree as
+          # sequencer so the bundled AbstractLineaOptionsPlugin / arithmetization
+          # classes match (otherwise NoSuchMethodError at plugin startup).
+          TRACER_JARS=("$TRACER_LIBS"/linea-tracer-*.jar)
+          if [[ ${#TRACER_JARS[@]} -eq 0 ]]; then
+            echo "ERROR: no linea-tracer-*.jar found in $TRACER_LIBS"; exit 1
+          fi
+          cp "${TRACER_JARS[0]}" docker-build/plugins/
+          echo "Installed tracer JAR: $(basename "${TRACER_JARS[0]}")"
+
+          # Extract both dist zips to collect dependency JARs. The besu-plugin-distribution
+          # plugin produces two zips per module; only one is populated.
+          rm -rf /tmp/plugin-deps
+          mkdir -p /tmp/plugin-deps
+          for zip_dir in "$SEQ_DIST" "$TRACER_DIST"; do
+            for z in "$zip_dir"/*.zip; do
+              if unzip -l "$z" 2>/dev/null | grep -qE "\.jar( |$)"; then
+                echo "Using distribution zip: $z"
+                unzip -q -o "$z" -d /tmp/plugin-deps
+              fi
+            done
           done
-          if [[ -z "$DIST_ZIP" ]]; then
-            echo "ERROR: no populated distribution zip with jars found in $DIST_DIR"; exit 1
-          fi
-          echo "Using distribution zip: $DIST_ZIP"
-
-          rm -rf /tmp/seq-deps
-          unzip -q "$DIST_ZIP" -d /tmp/seq-deps
 
           # Install plugin dependencies, excluding JARs already provided by the base image
-          EXCLUDE='(tuweni|besu-|linea-sequencer-|grpc-netty|grpc-core|grpc-util|grpc-context|grpc-api|netty-|guava-|gson-|error_prone|failureaccess|perfmark|animal-sniffer|jspecify)'
-          for jar in /tmp/seq-deps/*/*.jar; do
+          # and the plugin JARs themselves (already copied above).
+          EXCLUDE='(tuweni|besu-|linea-sequencer-|linea-tracer-|grpc-netty|grpc-core|grpc-util|grpc-context|grpc-api|netty-|guava-|gson-|error_prone|failureaccess|perfmark|animal-sniffer|jspecify)'
+          for jar in /tmp/plugin-deps/*/*.jar; do
             jarname=$(basename "$jar")
             if [[ ! "$jarname" =~ $EXCLUDE ]]; then
-              cp "$jar" docker-build/plugins/
+              cp -n "$jar" docker-build/plugins/
             fi
           done
 
           # Copy RLN native library
           cp besu-plugins/linea-sequencer/sequencer/src/main/rust/rln_bridge/target/release/librln_bridge.so docker-build/native/
+
+          # Upgrade shomei plugin (base image ships an older version)
+          SHOMEI_ZIP="besu-shomei-plugin-v${SHOMEI_PLUGIN_VERSION}.zip"
+          curl -fsSL -o "/tmp/${SHOMEI_ZIP}" \
+            "https://github.com/Consensys/besu-shomei-plugin/releases/download/v${SHOMEI_PLUGIN_VERSION}/${SHOMEI_ZIP}"
+          unzip -j -o "/tmp/${SHOMEI_ZIP}" -d docker-build/plugins/
+          rm -f "/tmp/${SHOMEI_ZIP}"
+          echo "Installed shomei plugin v${SHOMEI_PLUGIN_VERSION}"
 
           # Copy Dockerfile
           cp docker/status-network-besu/Dockerfile docker-build/
@@ -316,3 +336,4 @@ jobs:
             Multi-arch: linux/amd64 + linux/arm64
 
             Base Besu package: `consensys/linea-besu-package:${{ env.BESU_PACKAGE_TAG }}`
+            Shomei plugin: `v${{ env.SHOMEI_PLUGIN_VERSION }}`

--- a/docker/status-network-besu/Dockerfile
+++ b/docker/status-network-besu/Dockerfile
@@ -3,10 +3,16 @@ FROM consensys/linea-besu-package:${BESU_PACKAGE_TAG}
 
 USER root
 
-# Remove stock sequencer plugin (replaced by RLN-enabled version)
-RUN rm -f /opt/besu/plugins/linea-sequencer*.jar
+# Remove stock Linea plugins that we replace with versions built from this repo
+# (sequencer + tracer + their bundled arithmetization) and the shomei plugin
+# that we upgrade. Keeping the stock jars alongside ours causes classpath
+# conflicts (NoSuchMethodError on AbstractLineaOptionsPlugin).
+RUN rm -f /opt/besu/plugins/linea-sequencer*.jar \
+          /opt/besu/plugins/linea-tracer*.jar \
+          /opt/besu/plugins/arithmetization-*.jar \
+          /opt/besu/plugins/besu-shomei-plugin-*.jar
 
-# Install custom RLN-enabled sequencer plugin and its dependencies
+# Install custom RLN-enabled sequencer + tracer plugins, upgraded shomei, and deps
 COPY plugins/ /opt/besu/plugins/
 
 # Install RLN native library

--- a/scripts/build-rln-enabled-sequencer.sh
+++ b/scripts/build-rln-enabled-sequencer.sh
@@ -23,8 +23,11 @@ echo -e "  Sequencer: ${LINEA_SEQUENCER_DIR}"
 echo -e "  RLN Prover: ${STATUS_RLN_PROVER_DIR}"
 
 # Use the exact same image version as the official Linea setup
-BESU_PACKAGE_TAG="beta-v6-20260410083640-74d51b7"
+BESU_PACKAGE_TAG="beta-v6.2-20260413130658-9cb6f11"
 BESU_BASE_IMAGE="consensys/linea-besu-package:${BESU_PACKAGE_TAG}"
+
+# Shomei plugin version to upgrade to (base image ships an older version)
+SHOMEI_PLUGIN_VERSION="1.0.3"
 
 # Build options
 BUILD_PROVER=${BUILD_PROVER:-false}
@@ -48,9 +51,11 @@ Usage: $(basename "$0") [options]
 
 Builds the RLN-enabled Status Network Besu image.
 Extracts the official Linea Besu package, replaces the sequencer plugin with
-our custom RLN-enabled version, and adds the RLN native bridge library.
+our custom RLN-enabled version, upgrades besu-shomei-plugin, and adds the RLN
+native bridge library.
 
-Base Image: ${BESU_BASE_IMAGE}
+Base Image:    ${BESU_BASE_IMAGE}
+Shomei Plugin: v${SHOMEI_PLUGIN_VERSION}
 
 Options:
   --all                        Build everything (Besu + RLN Prover + Postgres)
@@ -197,20 +202,38 @@ echo -e "${GREEN}RLN Bridge ready for: ${RLN_ARCHS[*]}${NC}"
 echo -e "${BLUE}Step 2: Building custom sequencer JAR...${NC}"
 cd "$REPO_ROOT"
 
+# Wipe build/libs and build/distributions so stale artifacts from older
+# branches (e.g. linea-sequencer-beta-v4.4-rc7-dev-*.jar) cannot be picked up
+# by the globs below. Those shadow ours at runtime and cause NoSuchMethodError.
+rm -rf "${LINEA_SEQUENCER_DIR}/sequencer/build/libs" \
+       "${LINEA_SEQUENCER_DIR}/sequencer/build/distributions" \
+       "${REPO_ROOT}/tracer/plugins/build/libs" \
+       "${REPO_ROOT}/tracer/plugins/build/distributions"
+
 LINEA_DEV_ALLOW_WARNINGS=true ./gradlew \
     :besu-plugins:linea-sequencer:sequencer:jar \
     :besu-plugins:linea-sequencer:sequencer:assembleDist \
+    :tracer:plugins:jar \
+    :tracer:plugins:assembleDist \
     -x test -x checkSpdxHeader -x spotlessJavaCheck -x spotlessGroovyGradleCheck \
     --no-daemon --configure-on-demand
 
 SEQUENCER_JAR=$(ls -t "${LINEA_SEQUENCER_DIR}/sequencer/build/libs"/linea-sequencer-*.jar 2>/dev/null | head -1)
-SEQUENCER_DIST=$(ls -t "${LINEA_SEQUENCER_DIR}/sequencer/build/distributions"/linea-sequencer-*.zip 2>/dev/null | head -1)
+# Dist zip is named after the project (sequencer-*), not the jar archiveBaseName.
+SEQUENCER_DIST=$(ls -t "${LINEA_SEQUENCER_DIR}/sequencer/build/distributions"/sequencer-*.zip 2>/dev/null | head -1)
+TRACER_PLUGIN_JAR=$(ls -t "${REPO_ROOT}/tracer/plugins/build/libs"/linea-tracer-*.jar 2>/dev/null | head -1)
+TRACER_PLUGIN_DIST=$(ls -t "${REPO_ROOT}/tracer/plugins/build/distributions"/linea-tracer-*.zip 2>/dev/null | head -1)
 
 if [[ ! -f "$SEQUENCER_JAR" ]]; then
     echo -e "${RED}Error: Sequencer JAR not found!${NC}"
     exit 1
 fi
+if [[ ! -f "$TRACER_PLUGIN_JAR" ]]; then
+    echo -e "${RED}Error: Tracer plugin JAR not found!${NC}"
+    exit 1
+fi
 echo -e "${GREEN}Sequencer JAR: $(basename "$SEQUENCER_JAR")${NC}"
+echo -e "${GREEN}Tracer JAR: $(basename "$TRACER_PLUGIN_JAR")${NC}"
 
 ###############################################################################
 # Step 3: Build RLN Prover (optional)
@@ -242,17 +265,35 @@ docker create --name temp-besu-extract "${BESU_BASE_IMAGE}"
 docker cp temp-besu-extract:/opt/besu/ ./besu/
 docker rm temp-besu-extract
 
-# Replace sequencer plugin (keep all other Linea plugins)
-echo -e "${YELLOW}Installing custom sequencer plugin...${NC}"
-rm -f ./besu/plugins/linea-sequencer*.jar
+# Upgrade shomei plugin to the pinned version (base image may ship an older build)
+echo -e "${YELLOW}Upgrading besu-shomei-plugin to v${SHOMEI_PLUGIN_VERSION}...${NC}"
+SHOMEI_ZIP="besu-shomei-plugin-v${SHOMEI_PLUGIN_VERSION}.zip"
+SHOMEI_URL="https://github.com/Consensys/besu-shomei-plugin/releases/download/v${SHOMEI_PLUGIN_VERSION}/${SHOMEI_ZIP}"
+rm -f ./besu/plugins/besu-shomei-plugin-*.jar
+curl -fsSL -o "./${SHOMEI_ZIP}" "$SHOMEI_URL"
+unzip -j -o "./${SHOMEI_ZIP}" -d ./besu/plugins/
+rm -f "./${SHOMEI_ZIP}"
+echo -e "${GREEN}  Installed: besu-shomei-plugin-v${SHOMEI_PLUGIN_VERSION}${NC}"
+
+# Replace sequencer AND tracer plugins — both must come from the same source
+# tree so the bundled linea-plugins-common / arithmetization versions match
+# (mixing stock linea-tracer-*.jar with our sequencer causes NoSuchMethodError
+#  at startup due to shadowed AbstractLineaOptionsPlugin classes).
+echo -e "${YELLOW}Installing custom sequencer + tracer plugins...${NC}"
+rm -f ./besu/plugins/linea-sequencer*.jar \
+      ./besu/plugins/linea-tracer*.jar \
+      ./besu/plugins/arithmetization-*.jar
 cp "$SEQUENCER_JAR" ./besu/plugins/
+cp "$TRACER_PLUGIN_JAR" ./besu/plugins/
 echo -e "  Installed: $(basename "$SEQUENCER_JAR")"
+echo -e "  Installed: $(basename "$TRACER_PLUGIN_JAR")"
 
 # Install plugin dependencies in separate directory to avoid version conflicts
-if [[ -f "$SEQUENCER_DIST" ]]; then
+if [[ -f "$SEQUENCER_DIST" || -f "$TRACER_PLUGIN_DIST" ]]; then
     echo -e "${YELLOW}Installing plugin dependencies...${NC}"
     mkdir -p ./besu/plugins/lib
-    unzip -q "$SEQUENCER_DIST" -d extracted-deps/
+    [[ -f "$SEQUENCER_DIST" ]] && unzip -q "$SEQUENCER_DIST" -d extracted-deps/
+    [[ -f "$TRACER_PLUGIN_DIST" ]] && unzip -q -o "$TRACER_PLUGIN_DIST" -d extracted-deps/
     # Exclude JARs already provided by the base Besu image to avoid version conflicts.
     # NOTE: grpc-stub and grpc-protobuf are NOT in the base image — they must be included.
     # We exclude grpc-netty, grpc-core, grpc-api, grpc-context, grpc-util (all in base).


### PR DESCRIPTION
Upgrades base Linea besu package to `beta-v6.2-20260413130658-9cb6f11` and besu-shomei-plugin to v1.0.3. Also builds and replaces the tracer plugin from source so its `arithmetization` / `AbstractLineaOptionsPlugin` match the sequencer (avoids NoSuchMethodError at plugin load) in both the local build script and the release workflow.