### PR TITLE
fix(prover): allow base_fee = 0 for gasless chains

### DIFF
--- a/prover/backend/execution/craft_test.go
+++ b/prover/backend/execution/craft_test.go
@@ -15,7 +15,7 @@ func makeConfig(chainID, baseFee uint, coinBase, msgSvc ethcommon.Address) *conf
 	return &config.Config{
 		Layer2: struct {
 			ChainID           uint              `mapstructure:"chain_id" validate:"required"`
-			BaseFee           uint              `mapstructure:"base_fee" validate:"required"`
+			BaseFee           uint              `mapstructure:"base_fee"`
 			MsgSvcContractStr string            `mapstructure:"message_service_contract" validate:"required,eth_addr"`
 			MsgSvcContract    ethcommon.Address `mapstructure:"-"`
 			CoinBaseStr       string            `mapstructure:"coin_base" validate:"required,eth_addr"`

--- a/prover/config/config.go
+++ b/prover/config/config.go
@@ -61,6 +61,13 @@ func newConfigFromFile(path string, withValidation bool) (*Config, error) {
 		if err = validate.Struct(cfg); err != nil {
 			return nil, err
 		}
+
+		// Presence-check base_fee via viper. `required` on a uint rejects 0,
+		// which is valid on gasless chains. Keep the error format identical
+		// to the tag's output so tooling that parses it is unaffected.
+		if !viper.IsSet("layer2.base_fee") {
+			return nil, fmt.Errorf("Key: 'Config.Layer2.BaseFee' Error:Field validation for 'BaseFee' failed on the 'required' tag")
+		}
 	}
 
 	// Ensure cmdTmpl and cmdLargeTmpl are parsed
@@ -149,7 +156,10 @@ type Config struct {
 	Layer2 struct {
 		// ChainID stores the ID of the Linea L2 network to consider.
 		ChainID uint `mapstructure:"chain_id" validate:"required"`
-		BaseFee uint `mapstructure:"base_fee" validate:"required"`
+		// No validator tag: presence is enforced in newConfigFromFile via
+		// viper.IsSet. `required` would reject 0, which is valid on gasless
+		// chains where every block has baseFeePerGas=0.
+		BaseFee uint `mapstructure:"base_fee"`
 
 		// MsgSvcContractStr stores the unique ID of the Service Contract (SC), that is, it's
 		// address, as a string. The Service Contract (SC) is a smart contract that the L2


### PR DESCRIPTION
Swap `validate:"required"` on `Config.Layer2.BaseFee` for an explicit `viper.IsSet("layer2.base_fee")` check. `required` rejects 0 on a uint, blocking gasless L2 setups where every block has `baseFeePerGas=0`. Missing-field detection for non-gasless chains is preserved and the error format is unchanged.

Zero is ZK-safe: the execution circuit gates the baseFee public-input check with `mustBeEqualIfExtractedIsNonZero` in `prover/circuits/execution/pi_wizard_extraction.go`, so the constraint is trivially satisfied when the extracted block baseFee is 0.